### PR TITLE
DACT-391: Page not found screen

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import * as nunjucks from "nunjucks";
 import * as path from "path";
 import { router } from "./routes/routes";
 import * as urls from "./types/page.urls";
+import pageNotFound from "./controllers/error.controller";
 import { authenticationMiddleware } from "./middleware/authentication.middleware";
 import { sessionMiddleware } from "./middleware/session.middleware";
 import cookieParser from "cookie-parser";
@@ -24,8 +25,8 @@ const nunjucksEnv = nunjucks.configure([
 });
 
 nunjucksEnv.addGlobal("assetPath", process.env.CDN_HOST);
-//nunjucksEnv.addGlobal("PIWIK_URL", process.env.PIWIK_URL);
-//nunjucksEnv.addGlobal("PIWIK_SITE_ID", process.env.PIWIK_SITE_ID);
+nunjucksEnv.addGlobal("PIWIK_URL", process.env.PIWIK_URL);
+nunjucksEnv.addGlobal("PIWIK_SITE_ID", process.env.PIWIK_SITE_ID);
 
 app.enable("trust proxy");
 app.use(express.json());
@@ -52,7 +53,7 @@ app.use(`${urls.OFFICER_FILING}${urls.COMPANY_AUTH_PROTECTED_BASE}`, companyAuth
 app.use(commonTemplateVariablesMiddleware)
 // apply our default router to /officer-filing
 app.use(urls.OFFICER_FILING, router);
-//app.use(errorHandler);
+app.use(pageNotFound);
 
 logger.info("Officer filing Web has started");
 export default app;

--- a/src/controllers/error.controller.ts
+++ b/src/controllers/error.controller.ts
@@ -1,0 +1,18 @@
+import { Request, Response } from "express";
+import { Templates } from "../types/template.paths";
+
+const pageNotFound = (req: Request, res: Response) => {
+  return res.status(404).render(Templates.ERROR_404, { templateName: Templates.ERROR_404 });
+};
+
+/**
+ * This handler catches any other error thrown within the application.
+ * Use this error handler by calling next(e) from within a controller
+ * Always keep this as the last handler in the chain for it to work.
+ */
+// const errorHandler = (err: Error, req: Request, res: Response, _next: NextFunction) => {
+//   logger.errorRequest(req, `An error has occurred. Re-routing to the error screen - ${err.stack}`);
+//   res.status(500).render(Templates.SERVICE_OFFLINE_MID_JOURNEY, { templateName: Templates.SERVICE_OFFLINE_MID_JOURNEY });
+// };
+
+export default [pageNotFound];

--- a/src/types/template.paths.ts
+++ b/src/types/template.paths.ts
@@ -6,5 +6,5 @@ export enum Templates {
   CONFIRM_COMPANY = "confirm-company",
   REMOVE_DIRECTOR = "remove-director",
   REMOVE_DIRECTOR_CHECK_ANSWERS = "remove-director-check-answers",
-  
+  ERROR_404 = "page-not-found",
 }

--- a/views/page-not-found.html
+++ b/views/page-not-found.html
@@ -1,0 +1,19 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Page not found
+{% endblock %}
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">
+        Page not found
+      </h1>
+      <p>If you typed the web address, check it is correct.</p>
+      <p>If you pasted the web address, check you copied the entire address.</p>
+      <p>If the web address is correct or you selected a link or button, 
+        <a href="https://www.gov.uk/contact-companies-house" data-event-id="contact-companies-house-link">contact Companies House</a>.
+
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
[DACT-374](https://companieshouse.atlassian.net/browse/DACT-374)

Create Page Not Found screen:
A 404 error will need to show a 'Page Not Found' screen.
A page not found screen should be shown if someone is trying to view a page that does not exist.

[DACT-374]: https://companieshouse.atlassian.net/browse/DACT-374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ