### PR TITLE
Added feature flag

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import { router } from "./routes/routes";
 import * as urls from "./types/page.urls";
 import { pageNotFound, errorHandler } from "./controllers/error.controller";
+import { serviceAvailabilityMiddleware } from "./middleware/service.availability.middleware";
 import { authenticationMiddleware } from "./middleware/authentication.middleware";
 import { sessionMiddleware } from "./middleware/session.middleware";
 import cookieParser from "cookie-parser";
@@ -38,7 +39,7 @@ app.set("view engine", "html");
 
 // apply middleware
 app.use(cookieParser());
-//app.use(serviceAvailabilityMiddleware);
+app.use(serviceAvailabilityMiddleware);
 
 app.use(`${urls.OFFICER_FILING}*`, sessionMiddleware);
 

--- a/src/middleware/service.availability.middleware.ts
+++ b/src/middleware/service.availability.middleware.ts
@@ -1,0 +1,18 @@
+import { NextFunction, Request, Response } from "express";
+import { OFFICER_FILING_WEB_ACTIVE, EWF_URL } from "../utils/properties";
+import { Templates } from "../types/template.paths";
+import { isActiveFeature } from "../utils/feature.flag";
+
+/**
+ * Shows 500 page if config flag OFFICER_FILING_WEB_ACTIVE=false
+ */
+export const serviceAvailabilityMiddleware = (req: Request, res: Response, next: NextFunction) => {
+
+  if (!isActiveFeature(OFFICER_FILING_WEB_ACTIVE)) {
+    return res.render(Templates.SERVICE_OFFLINE_MID_JOURNEY, {EWF_URL});
+  }
+
+  return next();
+};
+
+

--- a/src/utils/properties.ts
+++ b/src/utils/properties.ts
@@ -33,6 +33,8 @@ const getEnvironmentVariable = (key: string, defaultValue?: any): string => {
   export const API_URL = getEnvironmentVariable("API_URL");
   
   export const INTERNAL_API_URL = getEnvironmentVariable("INTERNAL_API_URL");
+
+  export const OFFICER_FILING_WEB_ACTIVE = getEnvironmentVariable("OFFICER_FILING_WEB_ACTIVE", "false");
   
   export const FEATURE_FLAG_REMOVE_DIRECTOR_20022023 = "true"; //TODO  add the feature flag and then replace true with this get getEnvironmentVariable("FEATURE_FLAG_REMOVE_DIRECTOR_20022023");
   

--- a/test/global.setup.ts
+++ b/test/global.setup.ts
@@ -9,6 +9,7 @@ export default () => {
   process.env.COOKIE_DOMAIN = "cookie_domain";
   process.env.COOKIE_SECRET = "123456789012345678901234";
   process.env.EWF_URL = "https://ewf.companieshouse.gov.uk/";
+  process.env.OFFICER_FILING_WEB_ACTIVE = "true";
   process.env.FEATURE_FLAG_REMOVE_DIRECTOR_20022023 = "true";
   process.env.INTERNAL_API_URL = "http://localhost:9333";
   process.env.NODE_ENV = "development";

--- a/test/middleware/service.availability.middleware.unit.ts
+++ b/test/middleware/service.availability.middleware.unit.ts
@@ -1,0 +1,29 @@
+jest.mock("ioredis");
+jest.mock("../../src/utils/feature.flag");
+
+import request from "supertest";
+import app from "../../src/app";
+import { isActiveFeature } from "../../src/utils/feature.flag";
+
+const mockIsActiveFeature = isActiveFeature as jest.Mock;
+
+describe("service availability middleware tests", () => {
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return 500 error page", async () => {
+    mockIsActiveFeature.mockReturnValueOnce(false);
+    const response = await request(app).get("/officer-filing-web");
+
+    expect(response.text).toContain("Sorry, there is a problem with this service");
+  });
+
+  it("should not return 500 error page", async () => {
+    mockIsActiveFeature.mockReturnValueOnce(true);
+    const response = await request(app).get("/officer-filing-web");
+
+    expect(response.text).not.toContain("Sorry, there is a problem with this service");
+  });
+});

--- a/test/mocks/all.middleware.mock.ts
+++ b/test/mocks/all.middleware.mock.ts
@@ -1,4 +1,4 @@
-// import mockServiceAvailabilityMiddleware from "./service.availability.middleware.mock";
+import mockServiceAvailabilityMiddleware from "./service.availability.middleware.mock";
 import mockAuthenticationMiddleware from "./authentication.middleware.mock";
 import mockSessionMiddleware from "./session.middleware.mock";
 import mockCompanyAuthenticationMiddleware from "./company.authentication.middleware.mock";
@@ -8,7 +8,7 @@ import mockCompanyAuthenticationMiddleware from "./company.authentication.middle
 // import mockCompanyNumberQueryParameterValidationMiddleware from "./company.number.validation.middleware.mock";
 
 export default {
-  // mockServiceAvailabilityMiddleware,
+  mockServiceAvailabilityMiddleware,
   mockAuthenticationMiddleware,
   mockSessionMiddleware,
   mockCompanyAuthenticationMiddleware,

--- a/test/mocks/service.availability.middleware.mock.ts
+++ b/test/mocks/service.availability.middleware.mock.ts
@@ -1,0 +1,12 @@
+jest.mock("../../src/middleware/service.availability.middleware");
+
+import { NextFunction, Request, Response } from "express";
+import { serviceAvailabilityMiddleware } from "../../src/middleware/service.availability.middleware";
+
+// get handle on mocked function
+const mockServiceAvailabilityMiddleware = serviceAvailabilityMiddleware as jest.Mock;
+
+// tell the mock what to return
+mockServiceAvailabilityMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
+
+export default mockServiceAvailabilityMiddleware;


### PR DESCRIPTION
As Companies House

I need features flags to be added for filing the removal of a director via web service

So that I can hide features not yet intended for use 

Context

Refers to an engineering team’s ability to turn a feature or functionality on or off at their discretion.  We need to have such a capability in place for the API and Web service, if we realise there is an issue with a service when we release.


Feature Flag Name | Feature | Option | Active/Inactive | Outcome
-- | -- | -- | -- | --
OFFICER_FILING_WEB_ACTIVE | Web | On | Active | Service pages for the removal of a director
OFFICER_FILING_WEB_ACTIVE | Web | Off | In-active | Only the error 500 page
FEATURE_FLAG_ENABLE_TM01 | API | On | Active | Officer Filing API
FEATURE_FLAG_ENABLE_TM01 | API | Off | In-Active | Error 500 response

API throws a 404, was agreed as shown in the ticket comments to leave as is: https://companieshouse.atlassian.net/browse/DACT-315