### PR TITLE
fix/DACT-506-dissolved-company-page

### DIFF
--- a/src/controllers/confirm.company.controller.ts
+++ b/src/controllers/confirm.company.controller.ts
@@ -18,19 +18,9 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
     const companyNumber = req.query.companyNumber as string;
     const companyProfile: CompanyProfile = await getCompanyProfile(companyNumber);
 
-    if (await getCurrentOrFutureDissolved(session, companyNumber)){
-      const redirectUrl = urlUtils.setQueryParam(SHOW_STOP_PAGE_PATH, URL_QUERY_PARAM.COMPANY_NUM, companyNumber)
-      if (isValidUrl(redirectUrl)){
-        res.redirect(redirectUrl);
-      } else {
-        throw Error("URL to redirect to (" + redirectUrl + ") was not valid");
-      }
-    }
-    else {
-      const pageOptions = await buildPageOptions(session, companyProfile);
-      return res.render(Templates.CONFIRM_COMPANY, pageOptions);
-    }
-
+    const pageOptions = await buildPageOptions(session, companyProfile);
+    return res.render(Templates.CONFIRM_COMPANY, pageOptions);
+    
   } catch (e) {
     return next(e);
   }
@@ -54,12 +44,23 @@ const buildPageOptions = async (session: Session, companyProfile: CompanyProfile
 
 export const post = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const session: Session = req.session as Session;
 
+    const session: Session = req.session as Session;
+    const companyNumber = req.query.companyNumber as string;
+
+    if (await getCurrentOrFutureDissolved(session, companyNumber)){
+      const redirectUrl = urlUtils.setQueryParam(SHOW_STOP_PAGE_PATH, URL_QUERY_PARAM.COMPANY_NUM, companyNumber)
+      if (isValidUrl(redirectUrl)){
+        return res.redirect(redirectUrl);
+      } else {
+        throw Error("URL to redirect to (" + redirectUrl + ") was not valid");
+      }
+    }
+    
     await createNewOfficerFiling(session);
 
-    const companyNumber = req.query.companyNumber as string;
     const nextPageUrl = urlUtils.getUrlWithCompanyNumber(CREATE_TRANSACTION_PATH, companyNumber);
+
     if(isValidUrl(nextPageUrl)) {
       return res.redirect(nextPageUrl);
     } else {

--- a/test/controllers/confirm.company.controller.unit.ts
+++ b/test/controllers/confirm.company.controller.unit.ts
@@ -7,11 +7,12 @@ jest.mock("../../src/services/stop.page.validation.service");
 import mocks from "../mocks/all.middleware.mock";
 import request from "supertest";
 import app from "../../src/app";
-import { CONFIRM_COMPANY_PATH } from "../../src/types/page.urls";
+import { CONFIRM_COMPANY_PATH, SHOW_STOP_PAGE_PATH, URL_QUERY_PARAM, urlParams } from "../../src/types/page.urls";
 import { getCompanyProfile } from "../../src/services/company.profile.service";
 import { validCompanyProfile, dissolvedCompanyProfile } from "../mocks/company.profile.mock";
 import { formatForDisplay } from "../../src/services/confirm.company.service";
 import { getCurrentOrFutureDissolved } from "../../src/services/stop.page.validation.service";
+import { urlUtils } from "../../src/utils/url";
 
 const mockGetCompanyProfile = getCompanyProfile as jest.Mock;
 const mockFormatForDisplay = formatForDisplay as jest.Mock;
@@ -26,19 +27,7 @@ describe("Confirm company controller tests", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-  });
-
-  it("Should redirect to dissolved stop screen when company is dissolved", async () => {
-    mockGetCompanyProfile.mockResolvedValueOnce(dissolvedCompanyProfile);
-    mockFormatForDisplay.mockReturnValueOnce(dissolvedCompanyProfile);
-    mockGetCurrentOrFutureDissolved.mockReturnValueOnce(true);
-
-    const response = await request(app)
-    .get(CONFIRM_COMPANY_PATH)
-    .query({ companyNumber });
-
-    expect(response.text).toContain(DISSOLVED_PAGE_REDIRECT_HEADING);
-    expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
+    mockGetCurrentOrFutureDissolved.mockReset();
   });
 
   it("Should navigate to confirm company page", async () => {
@@ -87,5 +76,14 @@ describe("Confirm company controller tests", () => {
     expect(response.header.location).toEqual("/officer-filing-web/company/" + companyNumber + "/transaction");
   });
 
+  it("Should redirect to dissolved stop screen when company is dissolved", async () => {
+    mockGetCurrentOrFutureDissolved.mockReturnValueOnce(true);
+
+    const response = await request(app)
+      .post(CONFIRM_COMPANY_PATH + "?companyNumber=" + companyNumber);
+
+    expect(response.text).toEqual(DISSOLVED_PAGE_REDIRECT_HEADING);
+    expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
+  });
 });
 


### PR DESCRIPTION
Description

When traversing the officer filing web screens, the company is dissolved screen appears in the wrong place.

This needs to be altered so it correctly appears after the company confirmation screen.

Steps to reproduce

Click start now on officer-filing-web start page
(Sign in if required)
Enter the company number 01777777 and click continue

Actual result

The Company is dissolved screen appears

Expected result

The confirm company screen should appear
When confirm and continue is clicked
The Company is dissolved screen appears