### PR TITLE
DONT_MERGE

### DIFF
--- a/src/controllers/confirm.company.controller.ts
+++ b/src/controllers/confirm.company.controller.ts
@@ -18,19 +18,9 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
     const companyNumber = req.query.companyNumber as string;
     const companyProfile: CompanyProfile = await getCompanyProfile(companyNumber);
 
-    if (await getCurrentOrFutureDissolved(session, companyNumber)){
-      const redirectUrl = urlUtils.setQueryParam(SHOW_STOP_PAGE_PATH, URL_QUERY_PARAM.COMPANY_NUM, companyNumber)
-      if (isValidUrl(redirectUrl)){
-        res.redirect(redirectUrl);
-      } else {
-        throw Error("URL to redirect to (" + redirectUrl + ") was not valid");
-      }
-    }
-    else {
-      const pageOptions = await buildPageOptions(session, companyProfile);
-      return res.render(Templates.CONFIRM_COMPANY, pageOptions);
-    }
-
+    const pageOptions = await buildPageOptions(session, companyProfile);
+    return res.render(Templates.CONFIRM_COMPANY, pageOptions);
+    
   } catch (e) {
     return next(e);
   }
@@ -54,12 +44,23 @@ const buildPageOptions = async (session: Session, companyProfile: CompanyProfile
 
 export const post = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const session: Session = req.session as Session;
 
+    const session: Session = req.session as Session;
+    const companyNumber = req.query.companyNumber as string;
+
+    if (await getCurrentOrFutureDissolved(session, companyNumber)){
+      const redirectUrl = urlUtils.setQueryParam(SHOW_STOP_PAGE_PATH, URL_QUERY_PARAM.COMPANY_NUM, companyNumber)
+      if (isValidUrl(redirectUrl)){
+        return res.redirect(redirectUrl);
+      } else {
+        throw Error("URL to redirect to (" + redirectUrl + ") was not valid");
+      }
+    }
+    
     await createNewOfficerFiling(session);
 
-    const companyNumber = req.query.companyNumber as string;
     const nextPageUrl = urlUtils.getUrlWithCompanyNumber(CREATE_TRANSACTION_PATH, companyNumber);
+
     if(isValidUrl(nextPageUrl)) {
       return res.redirect(nextPageUrl);
     } else {

--- a/src/validation/request.input.validation.ts
+++ b/src/validation/request.input.validation.ts
@@ -1,0 +1,10 @@
+export const isValidUrl = (nextPageUrl: string ) => { 
+    if (nextPageUrl.startsWith("/officer-filing-web")) {
+      return true;
+    }
+    else {
+      return false;
+    }
+  };
+
+  //Will be used to validate URL inputs in future

--- a/test/controllers/confirm.company.controller.unit.ts
+++ b/test/controllers/confirm.company.controller.unit.ts
@@ -3,6 +3,8 @@ jest.mock("../../src/services/company.profile.service");
 jest.mock("../../src/services/confirm.company.service");
 jest.mock("../../src/utils/date");
 jest.mock("../../src/services/stop.page.validation.service");
+jest.mock("../../src/validation/request.input.validation");
+
 
 import mocks from "../mocks/all.middleware.mock";
 import request from "supertest";
@@ -12,11 +14,12 @@ import { getCompanyProfile } from "../../src/services/company.profile.service";
 import { validCompanyProfile, dissolvedCompanyProfile } from "../mocks/company.profile.mock";
 import { formatForDisplay } from "../../src/services/confirm.company.service";
 import { getCurrentOrFutureDissolved } from "../../src/services/stop.page.validation.service";
-import { urlUtils } from "../../src/utils/url";
+import { isValidUrl } from "../../src/validation/request.input.validation";
 
 const mockGetCompanyProfile = getCompanyProfile as jest.Mock;
 const mockFormatForDisplay = formatForDisplay as jest.Mock;
 const mockGetCurrentOrFutureDissolved = getCurrentOrFutureDissolved as jest.Mock;
+const mockIsValidUrl = isValidUrl as jest.Mock;
 
 const companyNumber = "12345678";
 const SERVICE_UNAVAILABLE_TEXT = "Sorry, there is a problem with this service";
@@ -28,12 +31,14 @@ describe("Confirm company controller tests", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetCurrentOrFutureDissolved.mockReset();
+    mockIsValidUrl.mockReset();
   });
 
   it("Should navigate to confirm company page", async () => {
     mockGetCompanyProfile.mockResolvedValueOnce(validCompanyProfile);
     mockFormatForDisplay.mockReturnValueOnce(validCompanyProfile);
     mockGetCurrentOrFutureDissolved.mockReturnValueOnce(false);
+    mockIsValidUrl.mockReturnValueOnce(true);
 
     const response = await request(app)
     .get(CONFIRM_COMPANY_PATH)
@@ -47,6 +52,7 @@ describe("Confirm company controller tests", () => {
     mockGetCompanyProfile.mockResolvedValueOnce(validCompanyProfile);
     mockFormatForDisplay.mockReturnValueOnce(validCompanyProfile);
     mockGetCurrentOrFutureDissolved.mockReturnValueOnce(false);
+    mockIsValidUrl.mockReturnValueOnce(true);
 
     const response = await request(app)
       .get(CONFIRM_COMPANY_PATH);
@@ -68,6 +74,7 @@ describe("Confirm company controller tests", () => {
   it("Should call private sdk client and redirect to transaction using company number in profile retrieved from database", async () => {
     mockGetCompanyProfile.mockResolvedValueOnce(validCompanyProfile);
     mockGetCurrentOrFutureDissolved.mockReturnValueOnce(false);
+    mockIsValidUrl.mockReturnValueOnce(true);
 
     const response = await request(app)
       .post(CONFIRM_COMPANY_PATH + "?companyNumber=" + companyNumber);
@@ -78,12 +85,23 @@ describe("Confirm company controller tests", () => {
 
   it("Should redirect to dissolved stop screen when company is dissolved", async () => {
     mockGetCurrentOrFutureDissolved.mockReturnValueOnce(true);
+    mockIsValidUrl.mockReturnValueOnce(true);
 
     const response = await request(app)
       .post(CONFIRM_COMPANY_PATH + "?companyNumber=" + companyNumber);
 
     expect(response.text).toEqual(DISSOLVED_PAGE_REDIRECT_HEADING);
     expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
+  });
+
+  it("Should return error page if error is url is invalid", async () => {
+    mockGetCurrentOrFutureDissolved.mockReturnValueOnce(false);
+    mockIsValidUrl.mockReturnValueOnce(false);
+
+    const response = await request(app)
+      .post(CONFIRM_COMPANY_PATH + "?companyNumber=" + companyNumber);
+
+    expect(response.text).toContain(SERVICE_UNAVAILABLE_TEXT);
   });
 });
 

--- a/test/controllers/confirm.company.controller.unit.ts
+++ b/test/controllers/confirm.company.controller.unit.ts
@@ -7,11 +7,12 @@ jest.mock("../../src/services/stop.page.validation.service");
 import mocks from "../mocks/all.middleware.mock";
 import request from "supertest";
 import app from "../../src/app";
-import { CONFIRM_COMPANY_PATH } from "../../src/types/page.urls";
+import { CONFIRM_COMPANY_PATH, SHOW_STOP_PAGE_PATH, URL_QUERY_PARAM, urlParams } from "../../src/types/page.urls";
 import { getCompanyProfile } from "../../src/services/company.profile.service";
 import { validCompanyProfile, dissolvedCompanyProfile } from "../mocks/company.profile.mock";
 import { formatForDisplay } from "../../src/services/confirm.company.service";
 import { getCurrentOrFutureDissolved } from "../../src/services/stop.page.validation.service";
+import { urlUtils } from "../../src/utils/url";
 
 const mockGetCompanyProfile = getCompanyProfile as jest.Mock;
 const mockFormatForDisplay = formatForDisplay as jest.Mock;
@@ -26,19 +27,7 @@ describe("Confirm company controller tests", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-  });
-
-  it("Should redirect to dissolved stop screen when company is dissolved", async () => {
-    mockGetCompanyProfile.mockResolvedValueOnce(dissolvedCompanyProfile);
-    mockFormatForDisplay.mockReturnValueOnce(dissolvedCompanyProfile);
-    mockGetCurrentOrFutureDissolved.mockReturnValueOnce(true);
-
-    const response = await request(app)
-    .get(CONFIRM_COMPANY_PATH)
-    .query({ companyNumber });
-
-    expect(response.text).toContain(DISSOLVED_PAGE_REDIRECT_HEADING);
-    expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
+    mockGetCurrentOrFutureDissolved.mockReset();
   });
 
   it("Should navigate to confirm company page", async () => {
@@ -87,5 +76,14 @@ describe("Confirm company controller tests", () => {
     expect(response.header.location).toEqual("/officer-filing-web/company/" + companyNumber + "/transaction");
   });
 
+  it("Should redirect to dissolved stop screen when company is dissolved", async () => {
+    mockGetCurrentOrFutureDissolved.mockReturnValueOnce(true);
+
+    const response = await request(app)
+      .post(CONFIRM_COMPANY_PATH + "?companyNumber=" + companyNumber);
+
+    expect(response.text).toEqual(DISSOLVED_PAGE_REDIRECT_HEADING);
+    expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
+  });
 });
 

--- a/test/validation/request.input.validation.unit.ts
+++ b/test/validation/request.input.validation.unit.ts
@@ -1,0 +1,16 @@
+import { isValidUrl } from "../../src/validation/request.input.validation";
+
+const validUrl = "/officer-filing-web/confirm-company?companyNumber=12345678";
+const invalidUrl = "/confirm-director?UrlIsInvalid";
+
+describe("formatTitleCase tests", () => {
+    it("should return true if url begins with officer-filing-web", () => {
+        const result: boolean = isValidUrl(validUrl);
+        expect(result).toBe(true);
+    })
+
+    it("should return false if url does not begin with officer-filing-web", () => {
+        const result: boolean = isValidUrl(invalidUrl);
+        expect(result).toBe(false);
+      })
+});


### PR DESCRIPTION
Description

When traversing the officer filing web screens, the company is dissolved screen appears in the wrong place.

This needs to be altered so it correctly appears after the company confirmation screen.

Steps to reproduce

Click start now on officer-filing-web start page
(Sign in if required)
Enter the company number 01777777 and click continue

Actual result

The Company is dissolved screen appears

Expected result

The confirm company screen should appear
When confirm and continue is clicked
The Company is dissolved screen appears