### PR TITLE
Dact 409 no directors stop screen

### DIFF
--- a/src/controllers/stop.screen.controller.ts
+++ b/src/controllers/stop.screen.controller.ts
@@ -25,8 +25,8 @@ const setContent = async (req: Request, stopType: string) => {
     const companyProfile: CompanyProfile = await getCompanyProfile(companyNumber);
 
     if (companyProfile.companyName === "") {
-        if(stopType === STOP_TYPE.DISSOLVED){
-            // Company name is at the start of the paragraph on the dissolved screen.
+        if(stopType === STOP_TYPE.DISSOLVED || stopType === STOP_TYPE.NO_DIRECTORS){
+            // Company name is at the start of the paragraph.
             companyProfile.companyName = "This company";
         } 
         else{
@@ -40,12 +40,17 @@ const setContent = async (req: Request, stopType: string) => {
                 pageHeader: STOP_PAGE_CONTENT.dissolved.pageHeader,
                 pageBody: STOP_PAGE_CONTENT.dissolved.pageBody.replace(new RegExp(COMPANY_NAME_PLACEHOLDER, 'g'), companyProfile.companyName)
             }
-            
-        } 
+        }
+        case STOP_TYPE.NO_DIRECTORS: { 
+            return {
+                pageHeader: STOP_PAGE_CONTENT.noDirectors.pageHeader,
+                pageBody: STOP_PAGE_CONTENT.noDirectors.pageBody.replace(new RegExp(COMPANY_NAME_PLACEHOLDER, 'g'), companyProfile.companyName)
+            }
+        }
         case STOP_TYPE.LIMITED_UNLIMITED: { 
             return {
-                pageHeader: STOP_PAGE_CONTENT.limited_unlimited.pageHeader,
-                pageBody: STOP_PAGE_CONTENT.limited_unlimited.pageBody.replace(new RegExp(COMPANY_NAME_PLACEHOLDER, 'g'), companyProfile.companyName)
+                pageHeader: STOP_PAGE_CONTENT.limitedUnlimited.pageHeader,
+                pageBody: STOP_PAGE_CONTENT.limitedUnlimited.pageBody.replace(new RegExp(COMPANY_NAME_PLACEHOLDER, 'g'), companyProfile.companyName)
             }
         } 
         default: { 

--- a/src/controllers/stop.screen.controller.ts
+++ b/src/controllers/stop.screen.controller.ts
@@ -23,14 +23,14 @@ const displayStopPage = (res: Response, content: {pageHeader: string, pageBody: 
 const setContent = async (req: Request, stopType: string) => {  
     const companyNumber = req.query[URL_QUERY_PARAM.COMPANY_NUM] as string;
     const companyProfile: CompanyProfile = await getCompanyProfile(companyNumber);
-
-    if (companyProfile.companyName === "") {
+    var companyName = companyProfile.companyName;
+    if (companyName === "") {
         if(stopType === STOP_TYPE.DISSOLVED || stopType === STOP_TYPE.NO_DIRECTORS){
             // Company name is at the start of the paragraph.
-            companyProfile.companyName = "This company";
+            companyName = "This company";
         } 
         else{
-            companyProfile.companyName = "this company";
+            companyName = "this company";
         }
     }
 
@@ -38,19 +38,19 @@ const setContent = async (req: Request, stopType: string) => {
         case STOP_TYPE.DISSOLVED: { 
             return {
                 pageHeader: STOP_PAGE_CONTENT.dissolved.pageHeader,
-                pageBody: STOP_PAGE_CONTENT.dissolved.pageBody.replace(new RegExp(COMPANY_NAME_PLACEHOLDER, 'g'), companyProfile.companyName)
+                pageBody: STOP_PAGE_CONTENT.dissolved.pageBody.replace(new RegExp(COMPANY_NAME_PLACEHOLDER, 'g'), companyName)
             }
         }
         case STOP_TYPE.NO_DIRECTORS: { 
             return {
                 pageHeader: STOP_PAGE_CONTENT.noDirectors.pageHeader,
-                pageBody: STOP_PAGE_CONTENT.noDirectors.pageBody.replace(new RegExp(COMPANY_NAME_PLACEHOLDER, 'g'), companyProfile.companyName)
+                pageBody: STOP_PAGE_CONTENT.noDirectors.pageBody.replace(new RegExp(COMPANY_NAME_PLACEHOLDER, 'g'), companyName)
             }
         }
         case STOP_TYPE.LIMITED_UNLIMITED: { 
             return {
                 pageHeader: STOP_PAGE_CONTENT.limitedUnlimited.pageHeader,
-                pageBody: STOP_PAGE_CONTENT.limitedUnlimited.pageBody.replace(new RegExp(COMPANY_NAME_PLACEHOLDER, 'g'), companyProfile.companyName)
+                pageBody: STOP_PAGE_CONTENT.limitedUnlimited.pageBody.replace(new RegExp(COMPANY_NAME_PLACEHOLDER, 'g'), companyName)
             }
         } 
         default: { 

--- a/src/services/active.directors.details.service.ts
+++ b/src/services/active.directors.details.service.ts
@@ -13,7 +13,11 @@ export const getListActiveDirectorDetails = async (session: Session, transaction
   const response: Resource<CompanyOfficer[]> | ApiErrorResponse = await ofService.getListActiveDirectorDetails(transactionId);
   const status = response.httpStatusCode as number;
 
-  if (status >= 400) {
+  // 404 is returned if no officers were found for the company
+  if(status === 404){
+    return [] as CompanyOfficer[];
+  }
+  else if (status >= 400) {
     const errorResponse = response as ApiErrorResponse;
     throw new Error(`Error retrieving active director details: ${JSON.stringify(errorResponse)}`);
   }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -86,7 +86,9 @@ export enum OFFICER_ROLE {
 
 export enum STOP_TYPE {
   DISSOLVED = "dissolved",
-  LIMITED_UNLIMITED ="limited-unlimited"
+  LIMITED_UNLIMITED = "limited-unlimited",
+  NO_DIRECTORS = "no directors"
+
 }
 
 export const STOP_PAGE_CONTENT = 
@@ -100,7 +102,7 @@ export const STOP_PAGE_CONTENT =
         <p><a href="https://www.gov.uk/contact-companies-house" data-event-id="contact-us-link">Contact us</a> if you have any questions.</p>
         `
     },
-    limited_unlimited:{
+    limitedUnlimited:{
         pageHeader: "Only limited and unlimited companies can use this service",
         pageBody: `<p>You can only file director updates for ` + COMPANY_NAME_PLACEHOLDER + ` using this service if it's a:</p>
         <ul>
@@ -113,5 +115,12 @@ export const STOP_PAGE_CONTENT =
         <p>If this is the wrong company, <a href="` + COMPANY_LOOKUP.replace("{","%7B").replace("}","%7D") + `" data-event-id="enter-a-different-company-number-link">go back and enter a different company number</a>.</p>
         <p><a href="https://www.gov.uk/contact-companies-house" data-event-id="contact-us-link">Contact us</a> if you have any questions.</p>
         `
-    }
+    },
+    noDirectors:{
+      pageHeader: "Company has no current directors",
+      pageBody: `<p>` + COMPANY_NAME_PLACEHOLDER + ` cannot use this service because it has no current directors.</p>
+      <p>If you want to appoint a director, you can use <a href="https://idam-ui.company-information.service.gov.uk/" data-event-id="webfiling-link">WebFiling</a> or a <a href="https://www.gov.uk/government/publications/appoint-a-director-ap01" data-event-id="paper-form-link">paper form</a>.</p>
+      <p><a href="https://www.gov.uk/contact-companies-house" data-event-id="contact-us-link">Contact us</a> if you have any questions.</p>
+      `
+  }
 }

--- a/test/controllers/active.directors.controller.unit.ts
+++ b/test/controllers/active.directors.controller.unit.ts
@@ -9,7 +9,7 @@ import app from "../../src/app";
 
 import { ACTIVE_DIRECTORS_PATH, urlParams } from "../../src/types/page.urls";
 import { companyAuthenticationMiddleware } from "../../src/middleware/company.authentication.middleware";
-import { mockCompanyOfficers, mockCompanyOfficersExtended } from "../mocks/active.director.details.mock";
+import { mockCompanyOfficersExtended } from "../mocks/active.director.details.mock";
 import { validCompanyProfile } from "../mocks/company.profile.mock";
 import { getListActiveDirectorDetails } from "../../src/services/active.directors.details.service";
 import { getCompanyProfile } from "../../src/services/company.profile.service";
@@ -24,6 +24,7 @@ mockGetCompanyProfile.mockResolvedValue(validCompanyProfile);
 const COMPANY_NUMBER = "12345678";
 const PAGE_HEADING = "Test Company";
 const ACTIVE_DIRECTOR_DETAILS_URL = ACTIVE_DIRECTORS_PATH.replace(`:${urlParams.PARAM_COMPANY_NUMBER}`, COMPANY_NUMBER);
+const NO_DIRECTORS_REDIRECT = "Found. Redirecting to /officer-filing-web/stop-page?companyNumber=12345678&stopType=no%20directors";
 
 describe("Active directors controller tests", () => {
 
@@ -102,5 +103,11 @@ describe("Active directors controller tests", () => {
         expect(mockGetCompanyOfficers).toHaveBeenCalled();
         expect(response.text.match(/Remove director/g) || []).toHaveLength(5);
       });  
+
+      it("Should redirect to no directors page if no officers are returned", async () => {
+        mockGetCompanyOfficers.mockResolvedValue([]);
+        const response = await request(app).get(ACTIVE_DIRECTOR_DETAILS_URL);
+        expect(response.text).toContain(NO_DIRECTORS_REDIRECT);
+      }); 
   });
 });

--- a/test/controllers/stop.screen.controller.unit.ts
+++ b/test/controllers/stop.screen.controller.unit.ts
@@ -12,10 +12,13 @@ const SERVICE_UNAVAILABLE_TEXT = "Sorry, there is a problem with this service";
 const SHOW_STOP_PAGE_PATH_URL = "/officer-filing-web/stop-page?companyNumber=12345678&stopType=";
 const SHOW_STOP_PAGE_PATH_URL_DISSOLVED = SHOW_STOP_PAGE_PATH_URL + "dissolved";
 const SHOW_STOP_PAGE_PATH_URL_NON_LIMITED_UNLIMITED = SHOW_STOP_PAGE_PATH_URL + "limited-unlimited";
+const SHOW_STOP_PAGE_PATH_URL_NO_DIRECTORS = SHOW_STOP_PAGE_PATH_URL + "no directors";
 const DISSOLVED_PAGE_HEADING = "Company is dissolved or in the process of being dissolved";
-const dissolvedPageBodyText = "cannot use this service because it has been dissolved, or it's in the process of being dissolved."
+const NO_DIRECTORS_PAGE_HEADING = "Company has no current directors";
+const DISSOLVED_PAGE_BODY_TEXT = "cannot use this service because it has been dissolved, or it's in the process of being dissolved.";
 const NON_LIMITED_UNLIMITED_PAGE_HEADING = "Only limited and unlimited companies can use this service";
-const nonLimitedUnlimitedPageBodyText = "You can only file director updates for Test Company using this service if it's a:"
+const NON_LIMITED_UNLIMITED_PAGE_BODY_TEXT = "You can only file director updates for Test Company using this service if it's a:";
+const NO_DIRECTORS_PAGE_BODY_TEXT = "cannot use this service because it has no current directors.";
 
 describe("Stop screen controller tests", () => {
   beforeEach(() => {
@@ -40,7 +43,26 @@ describe("Stop screen controller tests", () => {
 
     expect(response.text).toContain(DISSOLVED_PAGE_HEADING);
     expect(response.text).toContain(dissolvedCompanyProfile.companyName);
-    expect(response.text).toContain(dissolvedPageBodyText);
+    expect(response.text).toContain(DISSOLVED_PAGE_BODY_TEXT);
+  });
+
+  it("Should navigate to no directors stop screen", async () => {
+    mockGetCompanyProfile.mockResolvedValueOnce(overseaCompanyCompanyProfile);
+    const response = await request(app)
+    .get(SHOW_STOP_PAGE_PATH_URL_NO_DIRECTORS);
+    expect(response.text).toContain(NO_DIRECTORS_PAGE_HEADING);
+    expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
+  });
+
+  it("Should set the content to no directors content", async () => {
+    mockGetCompanyProfile.mockResolvedValueOnce(overseaCompanyCompanyProfile);
+
+    const response = await request(app)
+      .get(SHOW_STOP_PAGE_PATH_URL_NO_DIRECTORS);
+
+    expect(response.text).toContain(NO_DIRECTORS_PAGE_HEADING);
+    expect(response.text).toContain(overseaCompanyCompanyProfile.companyName);
+    expect(response.text).toContain(NO_DIRECTORS_PAGE_BODY_TEXT);
   });
 
    it("Should navigate to non limited-unlimited stop screen", async () => {
@@ -60,14 +82,14 @@ describe("Stop screen controller tests", () => {
 
     expect(response.text).toContain(NON_LIMITED_UNLIMITED_PAGE_HEADING);
     expect(response.text).toContain(overseaCompanyCompanyProfile.companyName);
-    expect(response.text).toContain(nonLimitedUnlimitedPageBodyText);
+    expect(response.text).toContain(NON_LIMITED_UNLIMITED_PAGE_BODY_TEXT);
   });
-
+  
     it("Should substitute company name for 'This company' for dissolved company missing company name", async () => {
     mockGetCompanyProfile.mockResolvedValueOnce(dissolvedMissingNameCompanyProfile);
     const response = await request(app)
     .get(SHOW_STOP_PAGE_PATH_URL_DISSOLVED);
-    expect(response.text).toContain("This company " + dissolvedPageBodyText);
+    expect(response.text).toContain("This company " + DISSOLVED_PAGE_BODY_TEXT);
     expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
   });
 
@@ -75,9 +97,18 @@ describe("Stop screen controller tests", () => {
     mockGetCompanyProfile.mockResolvedValueOnce(overseaCompanyMissingNameCompanyProfile);
     const response = await request(app)
     .get(SHOW_STOP_PAGE_PATH_URL_NON_LIMITED_UNLIMITED);
-    expect(response.text).toContain(nonLimitedUnlimitedPageBodyText.replace("Test Company", "this company"));
+    expect(response.text).toContain(NON_LIMITED_UNLIMITED_PAGE_BODY_TEXT.replace("Test Company", "this company"));
     expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
   });
+
+  it("Should substitute company name for 'This company' for company with no directors missing company name", async () => {
+    mockGetCompanyProfile.mockResolvedValueOnce(overseaCompanyMissingNameCompanyProfile);
+    const response = await request(app)
+    .get(SHOW_STOP_PAGE_PATH_URL_NO_DIRECTORS);
+    expect(response.text).toContain("This company " + NO_DIRECTORS_PAGE_BODY_TEXT);
+    expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
+  });
+
 
   it("Should return error page if error is thrown when getting Company Profile", async () => {
     const message = "Can't connect";

--- a/test/services/active.director.details.service.unit.ts
+++ b/test/services/active.director.details.service.unit.ts
@@ -43,11 +43,11 @@ describe("Test active director details service", () => {
     expect(response).toEqual(mockCompanyOfficer);
   });
 
-  it("should throw error when http error code is returned", async () => {
+  it("should throw error when http error code 500 is returned", async () => {
 
     const errorMessage = "Oops! Someone stepped on the wire.";
     const errorResponse: ApiErrorResponse = {
-      httpStatusCode: 404,
+      httpStatusCode: 500,
       errors: [{ error: errorMessage }]
     };
 
@@ -64,5 +64,21 @@ describe("Test active director details service", () => {
 
     expect(actualMessage).toBeTruthy();
     expect(actualMessage).toEqual(expectedMessage);
+  });
+
+  it("should return an empty array when no officers are returned", async () => {
+
+    const errorMessage = "404 not found\n{}";
+    const errorResponse: ApiErrorResponse = {
+      httpStatusCode: 404,
+      errors: [{ error: errorMessage }]
+    };
+
+    mockGetActiveOfficerDetails.mockReturnValueOnce(errorResponse);
+    const session =  getSessionRequest({ access_token: "token" });
+
+    const response =  await getListActiveDirectorDetails(session, TRANSACTION_ID);
+
+    expect(response.length).toEqual(0);
   });
 });


### PR DESCRIPTION
Redirect to a stop screen where a company has no directors.
Can be tested by either removing all directors for a company under the appointments.appointments table, or setting their officer_role to "secretary". 

Should be tested alongside https://github.com/companieshouse/officer-filing-api/pull/89