### PR TITLE
Dact 461 close transaction

### DIFF
--- a/src/controllers/remove.director.check.answers.controller.ts
+++ b/src/controllers/remove.director.check.answers.controller.ts
@@ -1,11 +1,15 @@
 import { NextFunction, Request, Response } from "express";
-import { ACTIVE_DIRECTORS_PATH, REMOVE_DIRECTOR_PATH, REMOVE_DIRECTOR_SUBMITTED_PATH, urlParams } from "../types/page.urls";
+import { ACTIVE_DIRECTORS_PATH, REMOVE_DIRECTOR_PATH, REMOVE_DIRECTOR_SUBMITTED_PATH, BASIC_STOP_PAGE_PATH, URL_QUERY_PARAM, urlParams } from "../types/page.urls";
 import { Templates } from "../types/template.paths";
 import { urlUtils } from "../utils/url";
 import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
+import { ValidationStatusResponse } from "@companieshouse/api-sdk-node/dist/services/officer-filing";
+import { getValidationStatus } from "../services/validation.status.service";
+import { closeTransaction } from "../services/transaction.service";
 import { getCompanyProfile } from "../services/company.profile.service";
 import { CompanyOfficer } from "@companieshouse/api-sdk-node/dist/services/officer-filing/types";
 import { getDirectorAndTerminationDate } from "../services/remove.directors.check.answers.service";
+import { retrieveStopPageTypeToDisplay } from "../services/remove.directors.error.keys.service";
 import { Session } from "@companieshouse/node-session-handler";
 import { setAppointedOnDate, toReadableFormat, toReadableFormatMonthYear } from "../utils/date";
 import { equalsIgnoreCase } from "../utils/format";
@@ -59,6 +63,23 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
 
 export const post = async (req: Request, res: Response, next: NextFunction) => {
   try {
+    const transactionId = urlUtils.getTransactionIdFromRequestParams(req);
+    const submissionId = urlUtils.getSubmissionIdFromRequestParams(req);
+    const company: CompanyProfile = await getCompanyProfile(req.query.companyNumber as string);
+    const companyNumber = company.companyNumber;
+    const session: Session = req.session as Session;
+    
+    const validationStatus: ValidationStatusResponse = await getValidationStatus(session, transactionId, submissionId);
+    const stopQuery = retrieveStopPageTypeToDisplay(validationStatus);
+
+    if (stopQuery) {
+      return res.redirect(
+        urlUtils.setQueryParam(urlUtils.getUrlToPath(BASIC_STOP_PAGE_PATH, req), 
+        URL_QUERY_PARAM.PARAM_STOP_TYPE, stopQuery));
+    }
+
+    await closeTransaction(session, companyNumber, submissionId, transactionId);
+  
     return res.redirect(REMOVE_DIRECTOR_SUBMITTED_PATH);
   } catch (e) {
     return next(e);

--- a/src/controllers/remove.director.check.answers.controller.ts
+++ b/src/controllers/remove.director.check.answers.controller.ts
@@ -65,8 +65,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const transactionId = urlUtils.getTransactionIdFromRequestParams(req);
     const submissionId = urlUtils.getSubmissionIdFromRequestParams(req);
-    const company: CompanyProfile = await getCompanyProfile(req.query.companyNumber as string);
-    const companyNumber = company.companyNumber;
+    const companyNumber = urlUtils.getCompanyNumberFromRequestParams(req);
     const session: Session = req.session as Session;
     
     const validationStatus: ValidationStatusResponse = await getValidationStatus(session, transactionId, submissionId);

--- a/src/controllers/remove.director.controller.ts
+++ b/src/controllers/remove.director.controller.ts
@@ -17,7 +17,7 @@ import {
   RemovalDateKey,
   RemovalDateKeys
 } from "../model/date.model";
-import { retrieveErrorMessageToDisplay, retrieveStopPageTypeToDisplay } from "../services/remove.directors.date.service";
+import { retrieveErrorMessageToDisplay, retrieveStopPageTypeToDisplay } from "../services/remove.directors.error.keys.service";
 import { patchOfficerFiling, postOfficerFiling } from "../services/officer.filing.service";
 import { Session } from "@companieshouse/node-session-handler";
 import { CompanyAppointment } from "private-api-sdk-node/dist/services/company-appointments/types";

--- a/src/services/remove.directors.error.keys.service.ts
+++ b/src/services/remove.directors.error.keys.service.ts
@@ -2,7 +2,6 @@ import { ValidationStatusResponse } from "@companieshouse/api-sdk-node/dist/serv
 import { convertAPIMessageToKey, lookupWebValidationMessage } from "../utils/api.enumerations";
 import { STOP_TYPE } from "../utils/constants";
 
-
 export const retrieveErrorMessageToDisplay = (validationStatusResponse: ValidationStatusResponse): string => {
 
     var listOfValidationKeys = new Array();
@@ -39,15 +38,19 @@ export const retrieveErrorMessageToDisplay = (validationStatusResponse: Validati
    */
   export const retrieveStopPageTypeToDisplay = (validationStatusResponse: ValidationStatusResponse): string => {
     var listOfValidationKeys = new Array();
+    
     if (!validationStatusResponse.errors) {
         return "";
     }
 
-    validationStatusResponse.errors.forEach(element => {
-      listOfValidationKeys.push(convertAPIMessageToKey(element.error));
+    validationStatusResponse.errors?.forEach(element => {
+        listOfValidationKeys.push(convertAPIMessageToKey(element.error));
     });
 
-    if (listOfValidationKeys.includes("removal-date-after-2009")) {
+    if (listOfValidationKeys.includes("company-dissolved")) {
+        return STOP_TYPE.DISSOLVED;
+    }
+    else if (listOfValidationKeys.includes("removal-date-after-2009")) {
         return STOP_TYPE.PRE_OCTOBER_2009;
     }
 

--- a/test/controllers/remove.director.check.answers.controller.unit.ts
+++ b/test/controllers/remove.director.check.answers.controller.unit.ts
@@ -2,6 +2,9 @@ jest.mock("../../src/middleware/company.authentication.middleware");
 jest.mock("../../src/services/remove.directors.check.answers.service");
 jest.mock("../../src/services/company.profile.service");
 jest.mock("../../src/utils/api.enumerations");
+jest.mock("../../src/services/validation.status.service");
+jest.mock("../../src/services/transaction.service");
+jest.mock("../../src/services/remove.directors.error.keys.service");
 
 import mocks from "../mocks/all.middleware.mock";
 import request from "supertest";
@@ -13,6 +16,11 @@ import { mockCompanyOfficer, mockCompanyOfficerMissingDateOfBirth, mockCompanyOf
 import { validCompanyProfile } from "../mocks/company.profile.mock";
 import { getDirectorAndTerminationDate } from "../../src/services/remove.directors.check.answers.service";
 import { getCompanyProfile } from "../../src/services/company.profile.service";
+import { getValidationStatus } from "../../src/services/validation.status.service";
+import { mockValidValidationStatusResponse, mockValidationStatusResponseList } from "../mocks/validation.status.response.mock";
+import { closeTransaction } from "../../src/services/transaction.service";
+import { retrieveStopPageTypeToDisplay } from "../../src/services/remove.directors.error.keys.service";
+import { STOP_TYPE } from "../../src/utils/constants";
 
 const mockCompanyAuthenticationMiddleware = companyAuthenticationMiddleware as jest.Mock;
 mockCompanyAuthenticationMiddleware.mockImplementation((req, res, next) => next());
@@ -20,10 +28,14 @@ const mockGetDirectorAndTerminationDate = getDirectorAndTerminationDate as jest.
 const mockGetCompanyProfile = getCompanyProfile as jest.Mock;
 mockGetDirectorAndTerminationDate.mockResolvedValue(mockCompanyOfficer);
 mockGetCompanyProfile.mockResolvedValue(validCompanyProfile);
+const mockGetValidationStatus = getValidationStatus as jest.Mock;
+const mockCloseTransaction = closeTransaction as jest.Mock;
+const mockRetrieveStopScreen = retrieveStopPageTypeToDisplay as jest.Mock;
 
 const COMPANY_NUMBER = "12345678";
 const PAGE_HEADING = "Test Company";
 const CHECK_ANSWERS_URL = REMOVE_DIRECTOR_CHECK_ANSWERS_PATH.replace(`:${urlParams.PARAM_COMPANY_NUMBER}`, COMPANY_NUMBER);
+const SERVICE_UNAVAILABLE_TEXT = "Sorry, there is a problem with this service";
 
 describe("Remove director check answers controller tests", () => {
 
@@ -32,6 +44,9 @@ describe("Remove director check answers controller tests", () => {
     mocks.mockSessionMiddleware.mockClear();
     mockGetDirectorAndTerminationDate.mockClear();
     mockGetCompanyProfile.mockClear();
+    mockGetValidationStatus.mockClear();
+    mockCloseTransaction.mockClear();
+    mockRetrieveStopScreen.mockClear();
   });
 
   describe("get tests", () => {
@@ -123,5 +138,41 @@ describe("Remove director check answers controller tests", () => {
       expect(response.text).toContain("Sorry, there is a problem with this service");
     });
 
+  });
+
+  describe("post tests", () => {
+    it("Should redirect to next page if no errors", async () => {
+      mockGetValidationStatus.mockResolvedValueOnce(mockValidValidationStatusResponse);
+      mockCloseTransaction.mockResolvedValueOnce("closed");
+
+      const response = await request(app).post(CHECK_ANSWERS_URL);
+
+      expect(mockGetValidationStatus).toHaveBeenCalled();
+      expect(mockCloseTransaction).toHaveBeenCalled();
+      expect(response.text).toContain("Found. Redirecting to /officer-filing-web/company/00006400/transaction/020002-120116-793219/submission/1/remove-director-submitted");
+    });
+
+    it("Should redirect to appropriate stop screen if validation status errors (DISSOLVED)", async () => {
+      mockGetValidationStatus.mockResolvedValueOnce(mockValidationStatusResponseList);
+      mockRetrieveStopScreen.mockReturnValueOnce(STOP_TYPE.DISSOLVED);
+      //mockCloseTransaction.mockResolvedValueOnce("closed");
+
+      const response = await request(app).post(CHECK_ANSWERS_URL);
+
+      expect(mockGetValidationStatus).toHaveBeenCalled();
+      expect(mockCloseTransaction).not.toHaveBeenCalled();
+      expect(response.text).toContain("Found. Redirecting to /officer-filing-web/company/12345678/stop-page?stopType=dissolved");
+    });
+
+    it("Should redirect to error 500 screen if close transaction returns errors", async () => {
+      mockGetValidationStatus.mockResolvedValueOnce(mockValidValidationStatusResponse);
+      mockCloseTransaction.mockRejectedValue(new Error("can't connect"));
+
+      const response = await request(app).post(CHECK_ANSWERS_URL);
+
+      expect(mockGetValidationStatus).toHaveBeenCalled();
+      expect(mockCloseTransaction).toHaveBeenCalled();
+      expect(response.text).toContain(SERVICE_UNAVAILABLE_TEXT);
+    });
   });
 });

--- a/test/controllers/remove.director.check.answers.controller.unit.ts
+++ b/test/controllers/remove.director.check.answers.controller.unit.ts
@@ -155,7 +155,6 @@ describe("Remove director check answers controller tests", () => {
     it("Should redirect to appropriate stop screen if validation status errors (DISSOLVED)", async () => {
       mockGetValidationStatus.mockResolvedValueOnce(mockValidationStatusResponseList);
       mockRetrieveStopScreen.mockReturnValueOnce(STOP_TYPE.DISSOLVED);
-      //mockCloseTransaction.mockResolvedValueOnce("closed");
 
       const response = await request(app).post(CHECK_ANSWERS_URL);
 

--- a/test/controllers/remove.director.controller.unit.ts
+++ b/test/controllers/remove.director.controller.unit.ts
@@ -3,7 +3,7 @@ jest.mock("../../src/services/company.profile.service");
 jest.mock("../../src/services/officer.filing.service");
 jest.mock("../../src/services/company.appointments.service");
 jest.mock("../../src/services/validation.status.service");
-jest.mock("../../src/services/remove.directors.date.service");
+jest.mock("../../src/services/remove.directors.error.keys.service");
 jest.mock("../../src/utils/api.enumerations");
 
 import mocks from "../mocks/all.middleware.mock";
@@ -19,7 +19,7 @@ import { getCompanyAppointmentFullRecord } from "../../src/services/company.appo
 import { validCompanyAppointment } from "../mocks/company.appointment.mock";
 import { getValidationStatus } from "../../src/services/validation.status.service";
 import { mockValidValidationStatusResponse, mockValidationStatusResponseList, mockValidationStatusResponsePreOct2009 } from "../mocks/validation.status.response.mock";
-import { retrieveErrorMessageToDisplay, retrieveStopPageTypeToDisplay } from "../../src/services/remove.directors.date.service";
+import { retrieveErrorMessageToDisplay, retrieveStopPageTypeToDisplay } from "../../src/services/remove.directors.error.keys.service";
 
 const mockCompanyAuthenticationMiddleware = companyAuthenticationMiddleware as jest.Mock;
 mockCompanyAuthenticationMiddleware.mockImplementation((req, res, next) => next());

--- a/test/mocks/validation.status.response.mock.ts
+++ b/test/mocks/validation.status.response.mock.ts
@@ -42,6 +42,13 @@ export const mockValidationStatusError5: ValidationStatusError = {
     locationType: "json-path"
 }
 
+export const mockValidationStatusError6: ValidationStatusError = {
+    error: "You cannot remove a director from a company that has been dissolved or is in the process of being dissolved",
+    location: "$./transactions/185318-541416-850071/officers/646f2b75f8b00c631d83feb2/validation_status",
+    type: "ch:validation",
+    locationType: "json-path"
+}
+
 export const mockValidationStatusErrorPreOct2009: ValidationStatusError = {
     error: "Enter a date that is on or after 1 October 2009. If the director was removed before this date, you must file form 288b instead",
     location: "$./transactions/185318-541416-850071/officers/646f2b75f8b00c631d83feb2/validation_status",
@@ -60,7 +67,7 @@ export const mockValidationStatusResponse: ValidationStatusResponse = {
 }
 
 export const mockValidationStatusResponseList: ValidationStatusResponse = {
-    errors: [mockValidationStatusError4, mockValidationStatusError2, mockValidationStatusError3, mockValidationStatusError5, mockValidationStatusError1],
+    errors: [mockValidationStatusError4, mockValidationStatusError2, mockValidationStatusError3, mockValidationStatusError5, mockValidationStatusError1, mockValidationStatusError6],
     isValid: false
 }
 

--- a/test/services/active.director.details.service.unit.ts
+++ b/test/services/active.director.details.service.unit.ts
@@ -36,7 +36,7 @@ describe("Test active director details service", () => {
     };
 
     mockGetActiveOfficerDetails.mockReturnValueOnce(resource);
-    const session =  getSessionRequest({ access_token: "token" });
+    const session =  getSessionRequest();
     const response = await getListActiveDirectorDetails(session, TRANSACTION_ID);
 
     expect(mockGetActiveOfficerDetails).toBeCalledWith(TRANSACTION_ID);
@@ -52,7 +52,7 @@ describe("Test active director details service", () => {
     };
 
     mockGetActiveOfficerDetails.mockReturnValueOnce(errorResponse);
-    const session =  getSessionRequest({ access_token: "token" });
+    const session =  getSessionRequest();
     const expectedMessage = "Error retrieving active director details: " + JSON.stringify(errorResponse);
     let actualMessage;
 
@@ -75,7 +75,7 @@ describe("Test active director details service", () => {
     };
 
     mockGetActiveOfficerDetails.mockReturnValueOnce(errorResponse);
-    const session =  getSessionRequest({ access_token: "token" });
+    const session =  getSessionRequest();
 
     const response =  await getListActiveDirectorDetails(session, TRANSACTION_ID);
 

--- a/test/services/remove.director.date.service.unit.ts
+++ b/test/services/remove.director.date.service.unit.ts
@@ -1,5 +1,5 @@
 import { mockValidValidationStatusResponse, mockValidationStatusResponse, mockValidationStatusResponseList, mockValidationStatusResponseList2, mockValidationStatusResponseList3, mockValidationStatusResponseList4, mockValidationStatusResponsePreOct2009 } from "../mocks/validation.status.response.mock";
-import { retrieveErrorMessageToDisplay, retrieveStopPageTypeToDisplay } from "../../src/services/remove.directors.date.service";
+import { retrieveErrorMessageToDisplay, retrieveStopPageTypeToDisplay } from "../../src/services/remove.directors.error.keys.service";
 
 describe("Test remove director date service", () => {
 

--- a/test/services/remove.director.error.keys.service.unit.ts
+++ b/test/services/remove.director.error.keys.service.unit.ts
@@ -1,0 +1,46 @@
+import { mockValidationStatusResponse, mockValidationStatusResponseList, mockValidationStatusResponseList2, mockValidationStatusResponseList3, mockValidationStatusResponseList4 } from "../mocks/validation.status.response.mock";
+import { retrieveErrorMessageToDisplay, retrieveStopPageTypeToDisplay } from "../../src/services/remove.directors.error.keys.service";
+import { STOP_TYPE } from "../../src/utils/constants";
+
+describe("Test remove director error keys service", () => {
+
+  describe("retrieveErrorMessageToDisplay tests", () => {
+
+    it("Should return first web error message that matches priority order", async () => {
+      const newMessage = retrieveErrorMessageToDisplay(mockValidationStatusResponseList);
+      expect(newMessage).toEqual("Date director was removed must be a real date");
+    });
+  
+    it("Should return next web error message that matches priority order", async () => {
+      const newMessage = retrieveErrorMessageToDisplay(mockValidationStatusResponseList2);
+      expect(newMessage).toEqual("Enter a date that is in the past");
+    });
+  
+    it("Should return next web error message that matches priority order", async () => {
+      const newMessage = retrieveErrorMessageToDisplay(mockValidationStatusResponseList3);
+      expect(newMessage).toEqual("Enter a date that is on or after the company's incorporation date");
+    });
+  
+    it("Should return next web error message that matches priority order", async () => {
+      const newMessage = retrieveErrorMessageToDisplay(mockValidationStatusResponseList4);
+      expect(newMessage).toEqual("Enter a date that is on or after the date the director was appointed");
+    });
+  
+    it("Should return empty string if message is not found", async () => {
+      const newMessage = retrieveErrorMessageToDisplay(mockValidationStatusResponse);
+      expect(newMessage).toEqual("");
+    });
+  });
+
+  describe("Test remove director error keys service", () => {
+    it("Should return first stop query that matches priority order", async () => {
+      const stopQuery = retrieveStopPageTypeToDisplay(mockValidationStatusResponseList);
+      expect(stopQuery).toEqual(STOP_TYPE.DISSOLVED);
+    });
+
+    it("Should return empty string if stop query is not found", async () => {
+      const stopQuery = retrieveStopPageTypeToDisplay(mockValidationStatusResponseList2);
+      expect(stopQuery).toEqual("");
+    });
+  });
+});

--- a/test/services/transaction.service.unit.ts
+++ b/test/services/transaction.service.unit.ts
@@ -128,27 +128,7 @@ describe("transaction service tests", () => {
   });
 
   describe("closeTransaction tests", () => {
-    it("Should extract payment url from headers", async () => {
-      const paymentUrl = "http://payment";
-      mockPutTransaction.mockResolvedValueOnce({
-        headers: {
-          "x-payment-required": paymentUrl
-        },
-        httpStatusCode: 200,
-        resource: {
-          reference: EXPECTED_REF,
-          companyNumber: COMPANY_NUMBER,
-          description: "desc",
-          status: "closed"
-        }
-      } as ApiResponse<Transaction>);
-
-      const url = await closeTransaction(session, COMPANY_NUMBER, CS_SUBMISSION_ID, TRANSACTION_ID);
-
-      expect(url).toBe(paymentUrl);
-    });
-
-    it("Should return undefined if payment header not present", async () => {
+    it("Should return status transaction status", async () => {
       mockPutTransaction.mockResolvedValueOnce({
         headers: {  },
         httpStatusCode: 200,
@@ -160,25 +140,24 @@ describe("transaction service tests", () => {
         }
       } as ApiResponse<Transaction>);
 
-      const url = await closeTransaction(session, COMPANY_NUMBER, CS_SUBMISSION_ID, TRANSACTION_ID);
+      const transactionStatus = await closeTransaction(session, COMPANY_NUMBER, CS_SUBMISSION_ID, TRANSACTION_ID);
 
-      expect(url).toBeUndefined();
+      expect(transactionStatus).toEqual("closed");
     });
 
-    it("Should return undefined if no headers present", async () => {
+    it("Should return undefined if no status present", async () => {
       mockPutTransaction.mockResolvedValueOnce({
         httpStatusCode: 200,
         resource: {
           reference: EXPECTED_REF,
           companyNumber: COMPANY_NUMBER,
           description: "desc",
-          status: "closed"
         }
       } as ApiResponse<Transaction>);
 
-      const url = await closeTransaction(session, COMPANY_NUMBER, CS_SUBMISSION_ID, TRANSACTION_ID);
+      const transactionStatus = await closeTransaction(session, COMPANY_NUMBER, CS_SUBMISSION_ID, TRANSACTION_ID);
 
-      expect(url).toBeUndefined();
+      expect(transactionStatus).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
The ‘Check your answers before submitting a removal of a Director' page is the 8th page in the happy path journey for the web service. It acts as a page where an Officer will review information such as Name, Date of Birth (for individual directors only), Appointed on and Removal Date to check to see if the information is correct before submitting the TM01. Additionally, there are four types of validation stop screens that occur when the user selects confirm and submit button, the company has already been dissolved, the ETAG is out of date (directors details updated), The service has gone down (API Validation - Error 500) and the director has already been removed. We will also be running and testing all of the back-end validation that needs to ran on this page before a closed transaction occurs (see dev notes).

When the officer clicks the ‘confirm and submit’ button and passes all validation, the officer will move to the 'Removal of a Director Submitted’ page

https://companieshouse.atlassian.net/browse/DACT-461

TEST NOTES
In mongoDB ensure the "CHS Internal Privileged Key" has {sensitive_data_privileges: true}
Company appoints will have to be turned off before accessing the list of active directors page (Ideally on the confirm company screen or before).
After accessing the active directors page, company appointments should be immediately switched back on.
The happy path can then be tested as normal and the transaction should be updated in the DB once the journey is complete.
To test the stop screen, set the company profile status to dissolved after accessing the active directors page.