### PR TITLE
DACT-434 Stop screen - etag is invalid

### DIFF
--- a/src/controllers/stop.screen.controller.ts
+++ b/src/controllers/stop.screen.controller.ts
@@ -66,6 +66,12 @@ const setContent = async (req: Request, stopType: string) => {
                     .replace(`:${urlParams.PARAM_APPOINTMENT_ID}`, appointmentId)
             }
         }
+        case STOP_TYPE.ETAG: { 
+            return {
+                pageHeader: STOP_PAGE_CONTENT.etag.pageHeader,
+                pageBody: STOP_PAGE_CONTENT.etag.pageBody
+            }
+        }
         default: { 
            throw Error("Unrecognised stop screen type: " + stopType); 
         } 

--- a/src/services/remove.directors.error.keys.service.ts
+++ b/src/services/remove.directors.error.keys.service.ts
@@ -53,7 +53,9 @@ export const retrieveErrorMessageToDisplay = (validationStatusResponse: Validati
     else if (listOfValidationKeys.includes("removal-date-after-2009")) {
         return STOP_TYPE.PRE_OCTOBER_2009;
     }
+    else if (listOfValidationKeys.includes("etag-invalid")) {
+        return STOP_TYPE.ETAG;
+    }
 
     return "";
   };
-  

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -90,7 +90,8 @@ export enum STOP_TYPE {
   DISSOLVED = "dissolved",
   LIMITED_UNLIMITED = "limited-unlimited",
   NO_DIRECTORS = "no directors",
-  PRE_OCTOBER_2009 = "pre-october-2009"
+  PRE_OCTOBER_2009 = "pre-october-2009",
+  ETAG = "etag"
 }
 
 export const STOP_PAGE_CONTENT = 
@@ -132,5 +133,12 @@ export const STOP_PAGE_CONTENT =
       <p>If the date entered is not correct, you can <a href="` + REMOVE_DIRECTOR_PATH + `" data-event-id="enter-a-different-date-link">enter a different date</a>.</p>
       <p><a href="https://www.gov.uk/contact-companies-house" data-event-id="contact-us-link">Contact us</a> if you have any questions.</p>
       `
-  }
+    },
+    etag:{
+      pageHeader: "Someone has already made updates for this director",
+      pageBody: `<p>Since you started using this service, someone else has submitted an update to this director's details.</p>
+      <p>If you still need to submit this update, you'll need to <a href="/officer-filing-web" data-event-id="start-the-service-again-link">start the service again</a>.</p>
+      <p><a href="https://www.gov.uk/contact-companies-house" data-event-id="contact-us-link">Contact us</a> if you have any questions.</p>
+      `
+    },
 }

--- a/test/mocks/validation.status.response.mock.ts
+++ b/test/mocks/validation.status.response.mock.ts
@@ -56,6 +56,13 @@ export const mockValidationStatusErrorPreOct2009: ValidationStatusError = {
     locationType: "json-path"
 }
 
+export const mockValidationStatusErrorEtag: ValidationStatusError = {
+    error: "The Director’s information was updated before you sent this submission. You will need to start again",
+    location: "$./transactions/185318-541416-850071/officers/646f2b75f8b00c631d83feb2/validation_status",
+    type: "ch:validation",
+    locationType: "json-path"
+}
+
 export const mockValidValidationStatusResponse: ValidationStatusResponse = {
     errors: [],
     isValid: true
@@ -88,5 +95,10 @@ export const mockValidationStatusResponseList4: ValidationStatusResponse = {
 
 export const mockValidationStatusResponsePreOct2009: ValidationStatusResponse = {
     errors: [mockValidationStatusErrorPreOct2009],
+    isValid: false
+}
+
+export const mockValidationStatusResponseEtag: ValidationStatusResponse = {
+    errors: [mockValidationStatusErrorEtag],
     isValid: false
 }

--- a/test/services/remove.director.error.keys.service.unit.ts
+++ b/test/services/remove.director.error.keys.service.unit.ts
@@ -1,10 +1,10 @@
-import { mockValidationStatusResponse, mockValidationStatusResponseList, mockValidationStatusResponseList2, mockValidationStatusResponseList3, mockValidationStatusResponseList4 } from "../mocks/validation.status.response.mock";
+import { mockValidationStatusResponse, mockValidationStatusResponseEtag, mockValidationStatusResponseList, mockValidationStatusResponseList2, mockValidationStatusResponseList3, mockValidationStatusResponseList4, mockValidationStatusResponsePreOct2009 } from "../mocks/validation.status.response.mock";
 import { retrieveErrorMessageToDisplay, retrieveStopPageTypeToDisplay } from "../../src/services/remove.directors.error.keys.service";
 import { STOP_TYPE } from "../../src/utils/constants";
 
 describe("Test remove director error keys service", () => {
 
-  describe("retrieveErrorMessageToDisplay tests", () => {
+  describe("retrieve error message tests", () => {
 
     it("Should return first web error message that matches priority order", async () => {
       const newMessage = retrieveErrorMessageToDisplay(mockValidationStatusResponseList);
@@ -32,7 +32,7 @@ describe("Test remove director error keys service", () => {
     });
   });
 
-  describe("Test remove director error keys service", () => {
+  describe("retrieve stop type tests", () => {
     it("Should return first stop query that matches priority order", async () => {
       const stopQuery = retrieveStopPageTypeToDisplay(mockValidationStatusResponseList);
       expect(stopQuery).toEqual(STOP_TYPE.DISSOLVED);
@@ -41,6 +41,16 @@ describe("Test remove director error keys service", () => {
     it("Should return empty string if stop query is not found", async () => {
       const stopQuery = retrieveStopPageTypeToDisplay(mockValidationStatusResponseList2);
       expect(stopQuery).toEqual("");
+    });
+
+    it("Should return pre october 2009 stop type", async () => {
+      const stopQuery = retrieveStopPageTypeToDisplay(mockValidationStatusResponsePreOct2009);
+      expect(stopQuery).toEqual(STOP_TYPE.PRE_OCTOBER_2009);
+    });
+
+    it("Should return etag stop type", async () => {
+      const stopQuery = retrieveStopPageTypeToDisplay(mockValidationStatusResponseEtag);
+      expect(stopQuery).toEqual(STOP_TYPE.ETAG);
     });
   });
 });

--- a/views/stop-page.html
+++ b/views/stop-page.html
@@ -10,7 +10,9 @@
         {{pageHeader | safe}}
       </h1>
 
-      {{pageBody | safe}}
+      <div class="govuk-body">
+        {{pageBody | safe}}
+      </div>
 
     </div>
   </div>


### PR DESCRIPTION
This is 1 of 4 stop screens that may occur when a user is on the check your answers page. When the user selects confirm and submit, the information is validated and four errors can occur. This specific stop screen ‘Someone has already made updates for this director' will comprise of the following:

Title: 
-   Someone has already made updates for this director

Content:
- Since you started using this service, someone else has submitted an update to this director's details.
- If you still need to submit this update, you'll need to [start the service again](https://remove-a-director.herokuapp.com/start?journey=gov).
- [Contact us](https://www.gov.uk/contact-companies-house) if you have any questions.

[DACT-434](https://companieshouse.atlassian.net/browse/DACT-434)

[DACT-434]: https://companieshouse.atlassian.net/browse/DACT-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ