### PR TITLE
DACT-504 Update filing response model to use id instead of submissionId

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@companieshouse/api-sdk-node": "^2.0.84",
+        "@companieshouse/api-sdk-node": "^2.0.88",
         "@companieshouse/node-session-handler": "^4.1.7",
         "@companieshouse/structured-logging-node": "^1.0.4",
         "@companieshouse/web-security-node": "^2.0.0",
@@ -662,9 +662,9 @@
       }
     },
     "node_modules/@companieshouse/api-sdk-node": {
-      "version": "2.0.84",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.84.tgz",
-      "integrity": "sha512-IvtbsSERnnQQ0pe9MBmfyh5jVPKLaTt3eaxKgLOYBc893eD0+4ya7Bl32Mn7p1UIlM/ytu2uidBIBQHA8m8NLw==",
+      "version": "2.0.88",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.88.tgz",
+      "integrity": "sha512-ppbF+Q96+HvIE0dVSQOYihWN1M2op/IerVYgNizsZlRQZFfxjauJBpOl0yrpooSl1NG8WMu99tBinRuw6ARmqg==",
       "dependencies": {
         "axios": "^0.21.4",
         "camelcase-keys": "~6.2.2",
@@ -8204,9 +8204,9 @@
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
     },
     "@companieshouse/api-sdk-node": {
-      "version": "2.0.84",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.84.tgz",
-      "integrity": "sha512-IvtbsSERnnQQ0pe9MBmfyh5jVPKLaTt3eaxKgLOYBc893eD0+4ya7Bl32Mn7p1UIlM/ytu2uidBIBQHA8m8NLw==",
+      "version": "2.0.88",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.88.tgz",
+      "integrity": "sha512-ppbF+Q96+HvIE0dVSQOYihWN1M2op/IerVYgNizsZlRQZFfxjauJBpOl0yrpooSl1NG8WMu99tBinRuw6ARmqg==",
       "requires": {
         "axios": "^0.21.4",
         "camelcase-keys": "~6.2.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/companieshouse/officer-filing-web#readme",
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^2.0.84",
+    "@companieshouse/api-sdk-node": "^2.0.88",
     "@companieshouse/node-session-handler": "^4.1.7",
     "@companieshouse/structured-logging-node": "^1.0.4",
     "@companieshouse/web-security-node": "^2.0.0",

--- a/src/controllers/remove.director.controller.ts
+++ b/src/controllers/remove.director.controller.ts
@@ -34,7 +34,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
     
     // Create and post officer filing and retrieve filing ID
     const filingResponse = await postOfficerFiling(session, transactionId, appointmentId);
-    filingId = filingResponse.submissionId;
+    filingId = filingResponse.id;
 
     // Get the director name from company appointments
     const appointment: CompanyAppointment = await getCompanyAppointmentFullRecord(session, companyNumber, appointmentId);

--- a/test/services/remove.director.check.answers.service.unit.ts
+++ b/test/services/remove.director.check.answers.service.unit.ts
@@ -37,7 +37,7 @@ describe("Test check your answers service", () => {
     };
 
     mockGetDirectorAndTerminationDate.mockReturnValueOnce(resource);
-    const session =  getSessionRequest({ access_token: "token" });
+    const session =  getSessionRequest();
     const response = await getDirectorAndTerminationDate(session, TRANSACTION_ID, SUBMISSION_ID);
 
     expect(mockGetDirectorAndTerminationDate).toBeCalledWith(TRANSACTION_ID, SUBMISSION_ID);
@@ -53,7 +53,7 @@ describe("Test check your answers service", () => {
     };
 
     mockGetDirectorAndTerminationDate.mockReturnValueOnce(errorResponse);
-    const session =  getSessionRequest({ access_token: "token" });
+    const session =  getSessionRequest();
     const expectedMessage = "Error retrieving TM01 check your answers details: " + JSON.stringify(errorResponse);
     let actualMessage;
 


### PR DESCRIPTION
Use an updated version of the filing response dto that is returned when either a post or patch is done.

[DACT-504](https://companieshouse.atlassian.net/browse/DACT-504)

[DACT-504]: https://companieshouse.atlassian.net/browse/DACT-504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[API PR](https://github.com/companieshouse/officer-filing-api/pull/98)