### PR TITLE
DACT-570-Update-Allowed-Companies

### DIFF
--- a/src/controllers/confirm.company.controller.ts
+++ b/src/controllers/confirm.company.controller.ts
@@ -7,7 +7,7 @@ import { urlUtils } from "../utils/url";
 import { getCompanyProfile } from "../services/company.profile.service";
 import { buildAddress, formatForDisplay } from "../services/confirm.company.service";
 import { getCurrentOrFutureDissolved } from "../services/stop.page.validation.service";
-import { STOP_TYPE } from "../utils/constants";
+import { STOP_TYPE, allowedCompanyTypes } from "../utils/constants";
 
 export const isValidUrl = (url: string) => { 
   return url.startsWith("/officer-filing-web")
@@ -62,7 +62,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     if (await getCurrentOrFutureDissolved(session, companyNumber)){
       nextPageUrl = urlUtils.setQueryParam(nextPageUrl, URL_QUERY_PARAM.PARAM_STOP_TYPE, STOP_TYPE.DISSOLVED);
     }
-    else if(companyProfile.type !== "private-unlimited" && companyProfile.type !== "ltd" &&  companyProfile.type !== "plc"){
+    else if(!allowedCompanyTypes.includes(companyProfile.type)){
       nextPageUrl = urlUtils.setQueryParam(nextPageUrl, URL_QUERY_PARAM.PARAM_STOP_TYPE, STOP_TYPE.LIMITED_UNLIMITED);
     }
     else{

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -94,6 +94,15 @@ export enum STOP_TYPE {
   ETAG = "etag"
 }
 
+export const allowedCompanyTypes = new Array(
+  "private-unlimited", 
+  "ltd", 
+  "plc", 
+  "private-limited-guarant-nsc-limited-exemption", 
+  "private-limited-guarant-nsc", 
+  "private-unlimited-nsc",
+  "private-limited-shares-section-30-exemption");
+
 export const STOP_PAGE_CONTENT = 
 {
     dissolved:{


### PR DESCRIPTION
As companies house 

I want to make sure that the correct companies can file a TM01, CH01 and AP01

So that officers filing for a TM01, CH01 and AP01 that are only of the correct company type

Acceptance Criteria: 

AC1: For the both API and Web we should be allowing the following Company types; 

"private-unlimited", 
"ltd", 
"plc",
"private-limited-guarant-nsc-limited-exemption",
 "private-limited-guarant-nsc", 
"private-unlimited-nsc", 
"private-limited-shares-section-30-exemption"
