### PR TITLE
Accessibility audit - Hidden text relating to check your answers page

### DIFF
--- a/views/includes/remove-director-check-answers-corporate-summary.html
+++ b/views/includes/remove-director-check-answers-corporate-summary.html
@@ -28,7 +28,7 @@
           {
             href: changeLink,
             text: "Change",
-            visuallyHiddenText: "address",
+            visuallyHiddenText: ["Date the director was removed from the company ", resignedOn] | join,
             attributes: {
               "data-event-id": "change-link"
             }

--- a/views/includes/remove-director-check-answers-summary.html
+++ b/views/includes/remove-director-check-answers-summary.html
@@ -36,7 +36,7 @@
           {
             href: changeLink,
             text: "Change",
-            visuallyHiddenText: "address",
+            visuallyHiddenText: ["Date the director was removed from the company ", resignedOn] | join,
             attributes: {
               "data-event-id": "change-link"
             }


### PR DESCRIPTION
The remove a director service has an accessibility assessment completed on the 10th of July.
It was raised within the report on the Check your answers page when inspecting the code for the change link
that the visually hidden text refers to address. 

However, it should instead say ‘Date the director was removed from the company'  If we are able to include whatever
the input for the date was within the hidden text without increasing this ticket’s complexity which would be nice to have.

https://companieshouse.atlassian.net/browse/DACT-646