### PR TITLE
Accessibility audit - Incorrect Heading tag applied on Submission Confirmation

### DIFF
--- a/views/remove-director-submitted.html
+++ b/views/remove-director-submitted.html
@@ -57,7 +57,7 @@
           ]
         }) }}
 
-        <h3 class="govuk-heading-m">What happens next</h3>
+        <h2 class="govuk-heading-m">What happens next</h2>
 
         <p class="govuk-body">We'll send a confirmation email to you which contains your reference number.</p>
 


### PR DESCRIPTION
The remove a director service has an accessibility assessment completed on the 10th of July. 
It was noted in the report -  [Remove-A-Company-Director-Accessibility-Audit.docx](https://companieshouse-my.sharepoint.com/:w:/r/personal/jfrancis_companieshouse_gov_uk/Documents/Remove-A-Company-Director-Accessibility-Audit.docx?d=w9b129640babc4e0caae109b72530b97a&csf=1&web=1&e=Xky9Rm) -
that on the submission confirmation page, the wrong type of header formatting has been applied to the submission confirmation page.

Where on the screen it says What happens next - it is currently using H3 formatting.

This heading needs to be changed so it is using H2.

https://companieshouse.atlassian.net/browse/DACT-647