### PR TITLE
DACT-565 re-render director name when validation error occurs

### DIFF
--- a/src/controllers/remove.director.controller.ts
+++ b/src/controllers/remove.director.controller.ts
@@ -80,7 +80,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     if (validationStatus.errors) {
       const errorMessage = retrieveErrorMessageToDisplay(validationStatus);
       if (errorMessage) {
-        return displayErrorMessage(errorMessage, req, res);
+        return displayErrorMessage(errorMessage, appointment, req, res);
       }
      const stopPageType = retrieveStopPageTypeToDisplay(validationStatus);
      if (stopPageType) {
@@ -101,7 +101,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
 /**
  * Return the page with the rendered error message
  */
-function displayErrorMessage(errorMessage: string, req: Request, res: Response<any, Record<string, any>>) {
+function displayErrorMessage(errorMessage: string, appointment: CompanyAppointment, req: Request, res: Response<any, Record<string, any>>) {
   const errors = formatValidationError(errorMessage);
   const dates = {
     [RemovalDateKey]: RemovalDateKeys.reduce((o, key) => Object.assign(o, { [key]: req.body[key] }), {})
@@ -109,6 +109,7 @@ function displayErrorMessage(errorMessage: string, req: Request, res: Response<a
   const backLink = OFFICER_FILING + req.route.path.replace(REMOVE_DIRECTOR_PATH_END, ACTIVE_OFFICERS_PATH_END);
 
   return res.render(Templates.REMOVE_DIRECTOR, {
+    directorName: appointment.name,
     backLinkUrl: backLink,
     templateName: Templates.REMOVE_DIRECTOR,
     ...req.body,

--- a/src/middleware/validation.middleware.ts
+++ b/src/middleware/validation.middleware.ts
@@ -8,9 +8,17 @@ import {
 import { logger } from '../utils/logger';
 import { Templates } from "../types/template.paths";
 import { ACTIVE_OFFICERS_PATH_END, OFFICER_FILING, REMOVE_DIRECTOR_PATH_END } from "../types/page.urls";
+import { urlUtils } from "../utils/url";
+import { Session } from "@companieshouse/node-session-handler";
+import { CompanyAppointment } from "private-api-sdk-node/dist/services/company-appointments/types";
+import { getCompanyAppointmentFullRecord } from "../services/company.appointments.service";
 
-export function checkValidations(req: Request, res: Response, next: NextFunction) {
+export async function checkValidations(req: Request, res: Response, next: NextFunction) {
   try {
+    const companyNumber = urlUtils.getCompanyNumberFromRequestParams(req);
+    const appointmentId = urlUtils.getAppointmentIdFromRequestParams(req);
+    const session: Session = req.session as Session;
+
     const errorList = validationResult(req);
 
     if (!errorList.isEmpty()) {
@@ -18,14 +26,15 @@ export function checkValidations(req: Request, res: Response, next: NextFunction
 
       // Bypass the direct use of variables with dashes that
       // govukDateInput adds for day, month and year field
-      
       const dates = {
         [RemovalDateKey]: RemovalDateKeys.reduce((o, key) => Object.assign(o, { [key]: req.body[key] }), {})
       };
 
       const backLink = OFFICER_FILING + req.route.path.replace(REMOVE_DIRECTOR_PATH_END, ACTIVE_OFFICERS_PATH_END);
+      const appointment: CompanyAppointment = await getCompanyAppointmentFullRecord(session, companyNumber, appointmentId);
 
       return res.render(Templates.REMOVE_DIRECTOR, {
+        directorName: appointment.name,
         backLinkUrl: backLink,
         templateName: Templates.REMOVE_DIRECTOR,
         ...req.body,

--- a/test/controllers/remove.director.controller.unit.ts
+++ b/test/controllers/remove.director.controller.unit.ts
@@ -144,7 +144,7 @@ describe("Remove director date controller tests", () => {
                 "removal_date-year": "2010" });
 
         expect(response.text).toContain("Day must include numbers only");
-        expect(mockGetCompanyAppointmentFullRecord).not.toHaveBeenCalled();
+        expect(mockGetCompanyAppointmentFullRecord).toHaveBeenCalled();
         expect(mockGetValidationStatus).not.toHaveBeenCalled();
         expect(mockPatchOfficerFiling).not.toHaveBeenCalled();
     });
@@ -159,7 +159,7 @@ describe("Remove director date controller tests", () => {
                 "removal_date-year": "2010" });
 
         expect(response.text).toContain("Date must be a real date");
-        expect(mockGetCompanyAppointmentFullRecord).not.toHaveBeenCalled();
+        expect(mockGetCompanyAppointmentFullRecord).toHaveBeenCalled();
         expect(mockGetValidationStatus).not.toHaveBeenCalled();
         expect(mockPatchOfficerFiling).not.toHaveBeenCalled();
     });
@@ -174,7 +174,7 @@ describe("Remove director date controller tests", () => {
                 "removal_date-year": "" });
 
         expect(response.text).toContain("Date the director was removed must include a year");
-        expect(mockGetCompanyAppointmentFullRecord).not.toHaveBeenCalled();
+        expect(mockGetCompanyAppointmentFullRecord).toHaveBeenCalled();
         expect(mockGetValidationStatus).not.toHaveBeenCalled();
         expect(mockPatchOfficerFiling).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
When the date of removal page is first landed on, the officers name is shown at the top of the page as expected. The error occurs after an error is displayed to the user.

**Given** a date is entered that passes front-end validation but does not pass API validation (eg date is in the future)
**When** the user hits continue
**Then** The page is refreshed with the error displaying at the top of the page
**And** The officers name is still displayed at the top of the page

[DACT-565](https://companieshouse.atlassian.net/browse/DACT-565)

[DACT-565]: https://companieshouse.atlassian.net/browse/DACT-565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ