### PR TITLE
Dact-521-Check-Year-Is-4-Digits

### DIFF
--- a/src/validation/date.validation.ts
+++ b/src/validation/date.validation.ts
@@ -56,10 +56,9 @@ const DateValidation: DateValidationType = {
           link: RemovalDateField.MONTH
       },
       Year: {
-        //temporary bug fix to highlight all fields red
           messageKey: RemovalDateErrorMessageKey.INVALID_DATE,
-          source: [RemovalDateField.DAY, RemovalDateField.MONTH, RemovalDateField.YEAR],
-          link: RemovalDateField.DAY
+          source: [RemovalDateField.YEAR],
+          link: RemovalDateField.YEAR
       },
       DayMonth: {
           messageKey: RemovalDateErrorMessageKey.INVALID_DATE,

--- a/src/validation/date.validation.ts
+++ b/src/validation/date.validation.ts
@@ -56,9 +56,10 @@ const DateValidation: DateValidationType = {
           link: RemovalDateField.MONTH
       },
       Year: {
+        //temporary bug fix to highlight all fields red
           messageKey: RemovalDateErrorMessageKey.INVALID_DATE,
-          source: [RemovalDateField.YEAR],
-          link: RemovalDateField.YEAR
+          source: [RemovalDateField.DAY, RemovalDateField.MONTH, RemovalDateField.YEAR],
+          link: RemovalDateField.DAY
       },
       DayMonth: {
           messageKey: RemovalDateErrorMessageKey.INVALID_DATE,
@@ -142,7 +143,7 @@ const validateMissingValues = (dayStr: string, monthStr: string, yearStr: string
  * @returns A ValidationError object if one occurred, else undefined
  */
 const validateInvalidValues = (dayStr: string, monthStr: string, yearStr: string): ValidationError | undefined => {
-  const validDay = checkIsNumber(dayStr), validMonth = checkIsNumber(monthStr), validYear = checkIsNumber(yearStr);
+  const validDay = checkIsNumber(dayStr), validMonth = checkIsNumber(monthStr), validYear = checkIsValidYear(yearStr);
   if (!validDay && validMonth && validYear) {
     return DateValidation.InvalidValue.Day;
   }
@@ -169,6 +170,10 @@ const validateInvalidValues = (dayStr: string, monthStr: string, yearStr: string
 
 const checkIsNumber = (numStr: string) => {
   return numStr.match("^[0-9]+$");
+}
+
+const checkIsValidYear = (numStr: string) => {
+  return numStr.match("^[0-9]{4}$");
 }
 
 /**


### PR DESCRIPTION
Update the validation logic to be able to highlight multiple fields at once
General tidying to improve reusability of the validation elements
Update existing validation error messages
Move JS validation messages into api-enumerations
[DACT-521](https://companieshouse.atlassian.net/browse/DACT-521)

FIX TO CHECK YEAR IS 4 DIGITS LONG

[DACT-521]: https://companieshouse.atlassian.net/browse/DACT-521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ