### PR TITLE
DACT-655-Error-Screen-Back-Link

### DIFF
--- a/src/controllers/remove.director.controller.ts
+++ b/src/controllers/remove.director.controller.ts
@@ -117,7 +117,7 @@ function displayErrorMessage(validationResult: ValidationError, appointment: Com
   const dates = {
     [RemovalDateKey]: Object.values(RemovalDateField).reduce((o, key) => Object.assign(o as string, { [key as string]: req.body[key as string] }), {})
   };
-  const backLink = OFFICER_FILING + req.route.path.replace(DATE_DIRECTOR_REMOVED_PATH_END, ACTIVE_OFFICERS_PATH_END);
+  const backLink = urlUtils.getUrlToPath(CURRENT_DIRECTORS_PATH, req);
 
   return res.render(Templates.REMOVE_DIRECTOR, {
     directorName: formatTitleCase(retrieveDirectorNameFromAppointment(appointment)),


### PR DESCRIPTION
Description

Caught when testing - [[DACT-565] Date of Remove - Director name hidden when error summary component triggered - JIRA (atlassian.net)](https://companieshouse.atlassian.net/browse/DACT-565)

Context:

When a user has entered an invalid date on the date of removal page, the error summary appears at the top of the page.
In the event the user then clicks the back link (possible scenario for this would be if they wanted to check the appointed on date of the director or choose a different director). The user is presented with an error screen.
However the user should be redirected to the current directors page.

Replication steps
Navigate to the Date of Remove page
Input an invalid date and press continue to generate error summary on Date of Remove page
Press the back link button
The technical difficulties error screen will be present

Expected Behaviour
After pressing the back link after this error 
The user should be directed back to the current directors page

[DACT-565]: https://companieshouse.atlassian.net/browse/DACT-565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ