### PR TITLE
DACT-812 return empty string from web instead of undefined

### DIFF
--- a/src/utils/web.ts
+++ b/src/utils/web.ts
@@ -7,5 +7,5 @@ export const getField = (req: Request, fieldName: string): string|undefined => {
   if (field && field.trim().length > 0) {
     return field;
   }
-  return undefined;
+  return "";
 };

--- a/test/utils/web.unit.ts
+++ b/test/utils/web.unit.ts
@@ -2,31 +2,31 @@ import { getField } from "../../src/utils/web";
 import { Request } from 'express';
 
 describe('getField', () => {
-it('should return the value of the specified field if it exists and is not empty', () => {
-    const req: Request = { body: { name: 'John Doe' } } as Request;
-    const fieldName = 'name';
-    const result = getField(req, fieldName);
-    expect(result).toEqual('John Doe');
-});
+  it('should return the value of the specified field if it exists and is not empty', () => {
+      const req: Request = { body: { name: 'John Doe' } } as Request;
+      const fieldName = 'name';
+      const result = getField(req, fieldName);
+      expect(result).toEqual('John Doe');
+  });
 
-it('should return an empty string if the specified field does not exist', () => {
-    const req: Request = { body: {} } as Request;
-    const fieldName = 'name';
-    const result = getField(req, fieldName);
-    expect(result).toEqual('');
-});
+  it('should return an empty string if the specified field does not exist', () => {
+      const req: Request = { body: {} } as Request;
+      const fieldName = 'name';
+      const result = getField(req, fieldName);
+      expect(result).toEqual('');
+  });
 
-it('should return an empty string if the specified field is empty', () => {
-    const req: Request = { body: { name: '' } } as Request;
-    const fieldName = 'name';
-    const result = getField(req, fieldName);
-    expect(result).toEqual('');
-});
+  it('should return an empty string if the specified field is empty', () => {
+      const req: Request = { body: { name: '' } } as Request;
+      const fieldName = 'name';
+      const result = getField(req, fieldName);
+      expect(result).toEqual('');
+  });
 
-it('should not return null if the specified field is empty', () => {
-    const req: Request = { body: { name: '' } } as Request;
-    const fieldName = 'name';
-    const result = getField(req, fieldName);
-    expect(result).not.toBeNull();
-});
+  it('should not return null if the specified field is empty', () => {
+      const req: Request = { body: { name: '' } } as Request;
+      const fieldName = 'name';
+      const result = getField(req, fieldName);
+      expect(result).not.toBeNull();
+  });
 });

--- a/test/utils/web.unit.ts
+++ b/test/utils/web.unit.ts
@@ -1,0 +1,32 @@
+import { getField } from "../../src/utils/web";
+import { Request } from 'express';
+
+describe('getField', () => {
+it('should return the value of the specified field if it exists and is not empty', () => {
+    const req: Request = { body: { name: 'John Doe' } } as Request;
+    const fieldName = 'name';
+    const result = getField(req, fieldName);
+    expect(result).toEqual('John Doe');
+});
+
+it('should return an empty string if the specified field does not exist', () => {
+    const req: Request = { body: {} } as Request;
+    const fieldName = 'name';
+    const result = getField(req, fieldName);
+    expect(result).toEqual('');
+});
+
+it('should return an empty string if the specified field is empty', () => {
+    const req: Request = { body: { name: '' } } as Request;
+    const fieldName = 'name';
+    const result = getField(req, fieldName);
+    expect(result).toEqual('');
+});
+
+it('should not return null if the specified field is empty', () => {
+    const req: Request = { body: { name: '' } } as Request;
+    const fieldName = 'name';
+    const result = getField(req, fieldName);
+    expect(result).not.toBeNull();
+});
+});


### PR DESCRIPTION
If an officer submits blank data it should save to the Mongo DB, thus creating validation errors.
Issue: returning `undefined` results in null object and json parsing does not take place on api code, thus the patchedData is not updated if user goes back to previous page and clears the text boxes. 