### PR TITLE
DACT-692 Add Non-js typeahead alternative for name and occupation pages

### DIFF
--- a/views/director-occupation.html
+++ b/views/director-occupation.html
@@ -25,20 +25,21 @@
           <p class="govuk-body">This is optional. If you do not enter anything, we'll show the director's occupation as 'none' on the public Companies House register. 
           </p>
           <div id="my-autocomplete-container" class="govuk-form-group">
-          <h2 class="govuk-heading-s govuk-!-margin-bottom-1"> <label for="typeahead_input"> Occupation</label></h2>
-          <div id="typeahead-hint" class="govuk-hint">
-          Start typing an occupation (for example, carpenter) then choose from the list. <br> If your occupation is not shown, you can enter it directly into the box.
-        </div>
-          {% include "includes/inputs/fields/typeahead-input.html" %}
-        </div>
-        </div>
+            <h2 class="govuk-heading-s govuk-!-margin-bottom-1"> <label for="typeahead_input"> Occupation</label></h2>
 
+            {% set dropdownHint = "For example, carpenter." %}
+            {% set dropdownDefaultText = "Choose occupation" %}
+            {% set typeaheadHint = 'Start typing an occupation (for example, carpenter) then choose from the list. <br> If your occupation is not shown, you can enter it directly into the box.' | safe %}
+
+            {% include "includes/inputs/fields/typeahead-input.html" %}
+          </div>
+        </div>
 
         {{ govukInsetText({
           html: "<h2 class='govuk-heading-m'>What information we'll show on the public register</h2>
           <p>We will show the director's occupation on the public Companies House register.</p>"
         }) }}
-        
+    
         {{ govukButton({
           attributes: {
             "data-event-id": "continue-button"

--- a/views/includes/inputs/fields/title-input.html
+++ b/views/includes/inputs/fields/title-input.html
@@ -1,7 +1,10 @@
 <div id="my-autocomplete-container" class="govuk-form-group">
-<label for="typeahead_input" class="govuk-label" >Professional or honorary title (if relevant)</label>
-<div id="typeahead-hint" class="govuk-hint">
-  Start typing a title, such as Dr or Professor, then choose from the list.
-</div>
-{% include "includes/inputs/fields/typeahead-input.html" %}
+  <label for="typeahead_input" class="govuk-label" >Professional or honorary title (if relevant)</label>
+
+  {% set dropdownHint = "For example, Doctor or Professor." %}
+  {% set dropdownDefaultText = "Choose title" %}
+  {% set typeaheadHint = "Start typing a title, such as Dr or Professor, then choose from the list." %}
+
+  {% include "includes/inputs/fields/typeahead-input.html" %}
+  
 </div>

--- a/views/includes/inputs/fields/typeahead-input.html
+++ b/views/includes/inputs/fields/typeahead-input.html
@@ -1,16 +1,24 @@
 <script type="text/javascript" src="{{assetPath}}/javascripts/app/accessible-autocomplete.min.js"></script>
-
-
 <script type="text/javascript">
-const typeahead = "{{typeahead_array}}"
-const typeaheadArray = typeahead.split(",")
-accessibleAutocomplete({
-  element: document.querySelector('#my-autocomplete-container'),
-  id: 'typeahead_input', // To match it to the existing <label>.
-  source: typeaheadArray,
-  name: 'typeahead_input',
-  defaultValue:'{{typeahead_value}}'
-})
+
+  const typeahead = "{{typeahead_array}}"
+  const typeaheadArray = typeahead.split(',');
+
+  accessibleAutocomplete({
+    element: document.querySelector('#my-autocomplete-container'),
+    id: 'typeahead_input', // To match it to the existing <label>.
+    source: typeaheadArray,
+    name: 'typeahead_input',
+    defaultValue:'{{typeahead_value}}'
+  })
+
+  // Add hint to JS-enabled title
+  const hintElement = document.createElement('div');
+  hintElement.id = 'typeahead-hint';
+  hintElement.className = 'govuk-hint';
+  hintElement.innerHTML = '{{typeaheadHint}}';
+  const autocompleteContainer = document.getElementById("my-autocomplete-container");
+  autocompleteContainer.insertBefore(hintElement, autocompleteContainer.childNodes[2]);
 
   // Mimic nunjucks error generation
   window.onload = function () {
@@ -46,6 +54,27 @@ accessibleAutocomplete({
     const observer = new MutationObserver(callback);
     observer.observe(typeaheadNode, config);
   }
-
-
 </script>
+
+<!-- Javascript disabled -->
+<noscript>
+  {% set DROPDOWN = [
+    { value: '', text: dropdownDefaultText }
+  ] %}
+
+  {% for i in typeahead_array.split(',') %}
+    {% set dropdownObject = { value: i, text: i, selected: typeahead_value === i } %}
+    {% set DROPDOWN = DROPDOWN.concat(dropdownObject) %}
+  {% endfor %}
+
+  {{ govukSelect({
+    errorMessage: errors.typeahead_input.text if errors,
+    id: "typeahead_input",
+    name: "typeahead_input",
+    value: typeahead_value,
+    hint: {
+      text: dropdownHint
+    },
+    items: DROPDOWN
+  }) }}
+</noscript>

--- a/views/layout.html
+++ b/views/layout.html
@@ -16,6 +16,7 @@
 {% from "govuk/components/date-input/macro.njk"          import govukDateInput %}
 {% from "govuk/components/panel/macro.njk"               import govukPanel %}
 {% from "govuk/components/pagination/macro.njk"          import govukPagination %}
+{% from "govuk/components/select/macro.njk"              import govukSelect %}
 
 
 {% block head %}


### PR DESCRIPTION
Alternative for typeahead input if the client has disabled javascript, a dropdown box will appear instead.