### PR TITLE
DACT-868 adding in a styles override to make it get the fonts from the correct place

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,22 @@
 # officer-filing-web
 Web front end for Officer Filing service 
 
+## DISCLAIMER ***********************************************************************
+Due to a problem with where GOV-UK Frontened looks for it's fonts, we have had to add an override
+in styles.html.
+The problem was that we are using the newer version of GOVUK-Frontend. Version 4.6.0.
+
+This newer version looks for the fonts in a different place to the older versions, it looks for them 
+in {cdnHost}/assets/fonts/{font name}
+
+older versions look for it in {cdnHost}/fonts/{font name}. So because the older versions looked for it there,  
+the cdn builder builds it and puts the fonts in that location, so when using the new GOV-UK Frontend,  
+it doesn’t find the fonts.
+
+We have added an override to tell it to look in the /fonts location instead, this will fix the symptom, 
+but not cure the problem, as any changes to the fonts urls in future GOV-UK Frontend releases, 
+will mean it will stop working.
+
 ### Requirements
 
 In order to run the service locally you will need the following:

--- a/views/includes/styles.html
+++ b/views/includes/styles.html
@@ -1,0 +1,23 @@
+<style>
+
+  @font-face {
+    font-family: "GDS Transport";
+    src: url("//{{ cdnHost }}/fonts/light-94a07e06a1-v2.woff2") format("woff2"), url("//{{ cdnHost }}/fonts/light-f591b13f7d-v2.woff") format("woff");
+    font-weight: normal;
+    font-style: normal;
+    font-display: fallback;
+  }
+
+  @font-face {
+    font-family: "GDS Transport";
+    src: url("//{{ cdnHost }}/fonts/bold-b542beb274-v2.woff2") format("woff2"), url("//{{ cdnHost }}/fonts/bold-affa96571d-v2.woff") format("woff");
+    font-weight: bold;
+    font-style: normal;
+    font-display: fallback;
+  }
+
+  .govuk-footer__copyright-logo {
+      background-image: url("//{{ cdnHost }}/images/govuk-crest-2x.png");
+  }
+
+</style>


### PR DESCRIPTION
In older versions of Gov-uk Front end,  it grabs the fonts from  {cdnHost}/fonts/{font name}, which is where the fonts are actually stored in AWS.

The newer version of GOV-UK Front end tries to get the fonts from  {cdnHost}/assets/fonts/{font name}, which then just gets a 404.

This override will make it look for the fonts in the older location,  but it's hardcoded, so prone to possible future breaks. If a permanent solution is come up with, as this will eventually affect all Ch services,  then a change will need to be made.

after speaking to Moses, i will also raise a Jira to get the urls into the config, to make it easier to change them.