### PR TITLE
DACT-1029 

### DIFF
--- a/src/controllers/director.protected.details.controller.ts
+++ b/src/controllers/director.protected.details.controller.ts
@@ -1,6 +1,11 @@
 import { NextFunction, Request, Response } from "express";
-import { APPOINT_DIRECTOR_CHECK_ANSWERS_PATH, DIRECTOR_CONFIRM_RESIDENTIAL_ADDRESS_PATH, DIRECTOR_CONFIRM_RESIDENTIAL_ADDRESS_PATH_END, 
-  DIRECTOR_RESIDENTIAL_ADDRESS_PATH, } from "../types/page.urls";
+import {
+  APPOINT_DIRECTOR_CHECK_ANSWERS_PATH,
+  DIRECTOR_CONFIRM_RESIDENTIAL_ADDRESS_PATH,
+  DIRECTOR_CONFIRM_RESIDENTIAL_ADDRESS_PATH_END,
+  DIRECTOR_RESIDENTIAL_ADDRESS_LINK_PATH,
+  DIRECTOR_RESIDENTIAL_ADDRESS_PATH,
+} from "../types/page.urls";
 import { Templates } from "../types/template.paths";
 import { urlUtils } from "../utils/url";
 import { formatValidationErrors } from '../validation/validation';
@@ -36,6 +41,9 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
 
 const  getBackLinkUrl = (req: Request, officerFiling: OfficerFiling) => {
   let returnPageUrl = officerFiling.protectedDetailsBackLink;
+  if(officerFiling.isMailingAddressSameAsHomeAddress === true) {
+    return urlUtils.getUrlToPath(DIRECTOR_RESIDENTIAL_ADDRESS_LINK_PATH, req);
+  }
   if (returnPageUrl?.includes(DIRECTOR_CONFIRM_RESIDENTIAL_ADDRESS_PATH_END)) {
     return urlUtils.getUrlToPath(DIRECTOR_CONFIRM_RESIDENTIAL_ADDRESS_PATH, req);
   } else if (returnPageUrl?.includes(DIRECTOR_RESIDENTIAL_ADDRESS_PATH)) {

--- a/test/controllers/director.protected.details.unit.ts
+++ b/test/controllers/director.protected.details.unit.ts
@@ -15,12 +15,15 @@ import { protectedDetailsErrorMessageKey } from "../../src/utils/api.enumeration
 import { directorAppliedToProtectDetailsValue } from "../../src/controllers/director.protected.details.controller";
 import { DirectorField } from "../../src/model/director.model";
 
-import { 
+import {
   DIRECTOR_PROTECTED_DETAILS_PATH,
   APPOINT_DIRECTOR_CHECK_ANSWERS_PATH,
   DIRECTOR_CONFIRM_RESIDENTIAL_ADDRESS_PATH_END,
   DIRECTOR_RESIDENTIAL_ADDRESS_PATH_END,
-  urlParams 
+  urlParams,
+  DIRECTOR_RESIDENTIAL_ADDRESS_LINK_PATH,
+  DIRECTOR_RESIDENTIAL_ADDRESS_PATH,
+  DIRECTOR_RESIDENTIAL_ADDRESS_LINK_PATH_END
 } from "../../src/types/page.urls";
 import { isActiveFeature } from "../../src/utils/feature.flag";
 
@@ -78,6 +81,24 @@ describe("Director protected details controller tests", () => {
         const response = await request(app).get(PAGE_URL).set({"referer": "protected-details"});
   
         expect(response.text).toContain(ERROR_PAGE_HEADING);
+      });
+
+      it(`Should populate back link to ${DIRECTOR_RESIDENTIAL_ADDRESS_LINK_PATH} if the flag isMailingAddressSameAsHomeAddress set to true`, async () => {
+        mockGetOfficerFiling.mockResolvedValueOnce({
+          isMailingAddressSameAsHomeAddress : true
+        });
+
+        const response = await request(app).get(PAGE_URL);
+        expect(response.text).toContain(DIRECTOR_RESIDENTIAL_ADDRESS_LINK_PATH_END);
+      });
+
+      it(`Should populate back link to ${DIRECTOR_RESIDENTIAL_ADDRESS_PATH} page if the flag isMailingAddressSameAsHomeAddress set to false`, async () => {
+        mockGetOfficerFiling.mockResolvedValueOnce({
+          isMailingAddressSameAsHomeAddress : false
+        });
+
+        const response = await request(app).get(PAGE_URL);
+        expect(response.text).toContain(DIRECTOR_RESIDENTIAL_ADDRESS_PATH_END);
       });
 
       it(`should navigate back button to residential address confirmation page if officerFiling.protectedDetailsBackLink includes ${DIRECTOR_CONFIRM_RESIDENTIAL_ADDRESS_PATH_END}`, async () => {


### PR DESCRIPTION
Set the back link to the residential address link page if the flag `isMailingAddressSameAsHomeAddress` set to true.