### PR TITLE
dact-1541 different back link when roa incomplete for search page

### DIFF
--- a/test/controllers/director.residential.address.search.controller.unit.ts
+++ b/test/controllers/director.residential.address.search.controller.unit.ts
@@ -1,13 +1,15 @@
 jest.mock("../../src/utils/feature.flag")
 jest.mock("../../src/services/officer.filing.service");
 jest.mock("../../src/services/postcode.lookup.service");
-
+jest.mock("../../src/services/company.profile.service");
 import mocks from "../mocks/all.middleware.mock";
 import request from "supertest";
 import app from "../../src/app";
 
 import {
   DIRECTOR_CONFIRM_RESIDENTIAL_ADDRESS_PATH,
+  DIRECTOR_CORRESPONDENCE_ADDRESS_PATH_END,
+  DIRECTOR_RESIDENTIAL_ADDRESS_PATH_END,
   DIRECTOR_RESIDENTIAL_ADDRESS_SEARCH_CHOOSE_ADDRESS_PATH,
   DIRECTOR_RESIDENTIAL_ADDRESS_SEARCH_PATH,
   urlParams
@@ -16,9 +18,14 @@ import { isActiveFeature } from "../../src/utils/feature.flag";
 import { getOfficerFiling, patchOfficerFiling } from "../../src/services/officer.filing.service";
 import { getUKAddressesFromPostcode, getIsValidUKPostcode } from "../../src/services/postcode.lookup.service";
 import { UKAddress } from "@companieshouse/api-sdk-node/dist/services/postcode-lookup";
+import { getCompanyProfile, mapCompanyProfileToOfficerFilingAddress } from "../../src/services/company.profile.service";
+import { mock } from "node:test";
 const mockGetOfficerFiling = getOfficerFiling as jest.Mock;
 const mockIsActiveFeature = isActiveFeature as jest.Mock;
 const mockPatchOfficerFiling = patchOfficerFiling as jest.Mock;
+const mockGetCompanyProfile = getCompanyProfile as jest.Mock;
+const mockMapCompanyProfileToOfficerFilingAddress = mapCompanyProfileToOfficerFilingAddress as jest.Mock;
+
 mockIsActiveFeature.mockReturnValue(true);
 const COMPANY_NUMBER = "12345678";
 const TRANSACTION_ID = "11223344";
@@ -76,6 +83,15 @@ const mockResponseEmptyBodyCaseInsensitivity : UKAddress[] = [
 
 const mockResponseBodyOfUKAddresses: UKAddress[] = [mockResponseBodyOfUKAddress1, mockResponseBodyOfUKAddress2];
 
+const validResidentialAddress = {
+  "premises": "123",
+  "addressLine1": "123 Main St",
+  "addressLine2": "London",
+  "locality": "London",
+  "postalCode": "SW1A 1AA",
+  "country": "England"
+};
+
 describe('Director residential address search controller test', () => {
 
   beforeEach(() => {
@@ -88,10 +104,40 @@ describe('Director residential address search controller test', () => {
     it("Should navigate to director residential address search page", async () => {
       mockGetOfficerFiling.mockResolvedValueOnce({
         directorName: "John Smith"
-      })
+      });
+      mockGetCompanyProfile.mockResolvedValueOnce({});
+      mockMapCompanyProfileToOfficerFilingAddress.mockReturnValueOnce(validResidentialAddress);
       const response = await request(app).get(PAGE_URL);
 
       expect(response.text).toContain(PAGE_HEADING);
+      expect(response.text).toContain(DIRECTOR_RESIDENTIAL_ADDRESS_PATH_END);
+      expect(response.text).not.toContain(DIRECTOR_CORRESPONDENCE_ADDRESS_PATH_END);
+      expect(mocks.mockCompanyAuthenticationMiddleware).toHaveBeenCalled();
+    });
+
+    it("Should navigate to director residential address search page with correspondence address back link when roa is incomplete", async () => {
+      mockGetOfficerFiling.mockResolvedValueOnce({
+        directorName: "John Smith"
+      });
+      mockGetCompanyProfile.mockResolvedValueOnce({});
+      mockMapCompanyProfileToOfficerFilingAddress.mockReturnValueOnce({ ... validResidentialAddress, premises: null });
+      const response = await request(app).get(PAGE_URL);
+
+      expect(response.text).toContain(PAGE_HEADING);
+      expect(response.text).toContain(DIRECTOR_CORRESPONDENCE_ADDRESS_PATH_END);
+      expect(mocks.mockCompanyAuthenticationMiddleware).toHaveBeenCalled();
+    });
+
+    it("Should navigate to director residential address search page with correspondence address back link when roa mapping fails", async () => {
+      mockGetOfficerFiling.mockResolvedValueOnce({
+        directorName: "John Smith"
+      });
+      mockGetCompanyProfile.mockResolvedValueOnce({});
+      mockMapCompanyProfileToOfficerFilingAddress.mockReturnValueOnce(undefined);
+      const response = await request(app).get(PAGE_URL);
+
+      expect(response.text).toContain(PAGE_HEADING);
+      expect(response.text).toContain(DIRECTOR_CORRESPONDENCE_ADDRESS_PATH_END);
       expect(mocks.mockCompanyAuthenticationMiddleware).toHaveBeenCalled();
     });
 
@@ -109,6 +155,8 @@ describe('Director residential address search controller test', () => {
           premises: 123
           } )
       })
+      mockGetCompanyProfile.mockResolvedValueOnce({});
+      mockMapCompanyProfileToOfficerFilingAddress.mockReturnValueOnce(validResidentialAddress);
       const response = await request(app).get(PAGE_URL);
 
       expect(response.text).toContain("SW1A1AA");
@@ -123,7 +171,10 @@ describe('Director residential address search controller test', () => {
       mockGetOfficerFiling.mockResolvedValueOnce({
         firstName: "John",
         lastName: "Smith"
-      })
+      });
+      mockGetCompanyProfile.mockResolvedValueOnce({});
+      mockMapCompanyProfileToOfficerFilingAddress.mockReturnValueOnce(validResidentialAddress);
+
       const response = await request(app).post(PAGE_URL)
       .send({"postcode": "%%%%%%", "premises": "ゃ"});
 
@@ -137,6 +188,9 @@ describe('Director residential address search controller test', () => {
     });
 
     it("Should displays errors on page if get validation status returns errors - order and priority test", async () => {
+      mockGetCompanyProfile.mockResolvedValueOnce({});
+      mockMapCompanyProfileToOfficerFilingAddress.mockReturnValueOnce(validResidentialAddress);
+
       const response = await request(app).post(PAGE_URL)
       .send({"postcode": "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%", 
              "premises": "ゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃゃ"});
@@ -148,6 +202,9 @@ describe('Director residential address search controller test', () => {
 
     it("Should display error when postcode lookup service returns false", async () => {
       mockGetIsValidUKPostcode.mockReturnValue(false);
+      mockGetCompanyProfile.mockResolvedValueOnce({});
+      mockMapCompanyProfileToOfficerFilingAddress.mockReturnValueOnce(validResidentialAddress);
+
       const response = await request(app).post(PAGE_URL).send({"postcode": "SW1A1XY"});
       
       expect(mockPatchOfficerFiling).not.toHaveBeenCalled();
@@ -198,5 +255,4 @@ describe('Director residential address search controller test', () => {
       expect(response.text).toContain("Found. Redirecting to " + CONFIRM_PAGE_URL);
     });
   });
-
 });


### PR DESCRIPTION
Make the backlink on the Home Address search page conditional on ROA being complete. If complete then ROA radio button page else Correspondence address radio page.

Given I'm on the Home Address search page 
And the ROA is incomplete
When I click back I should go to Correspondence Address (radio buttons) page


Given I'm on the Home Address search page 
And the ROA is complete (with premises and other fields)
When I click back I should go to Home Address (radio button) page

Held back for now. Possibly post MVP.

