### PR TITLE
DACT-2148

### DIFF
--- a/views/start.html
+++ b/views/start.html
@@ -2,7 +2,11 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% block pageTitle %}
- {% include "includes/page-title.html" %}
+  {% if CH01_ACTIVE === "true" %}
+    {{ i18n.appTitle }} - {{i18n.govUK}}
+  {% else %}
+    {{ i18n.appTitleAppointRemove }} - {{i18n.govUK}}
+  {% endif %}
 {% endblock %}
 
 {% block signoutBar %}


### PR DESCRIPTION
 revert changes to the start.html title to the previous version as it adds extra `-` in the title which breaks the smoke tests.