### PR TITLE
DACT-1556: Back link flow not registering in Matomo, event missing for go back to current directors

### DIFF
--- a/views/update/update-director-details.html
+++ b/views/update/update-director-details.html
@@ -111,7 +111,7 @@
               <a class="govuk-link" href="{{cancelLink}}" data-event-id="update-cancel-link">{{ i18n.cancel }}</a>
             </div>
           {% else %}
-            <button id="backToActiveDirectorsButton" name="back_to_active_directors" class="govuk-button govuk-button--secondary govuk-!-margin-right-2" data-module="govuk-button" value="no-change">
+            <button id="backToActiveDirectorsButton" name="back_to_active_directors" class="govuk-button govuk-button--secondary govuk-!-margin-right-2" data-module="govuk-button" value="no-change" data-event-id="go-back-to-current-directors-button">
               {{ i18n.updateDirectorDetailsGoBackButton }}
             </button>
           {% endif %}


### PR DESCRIPTION
JIRA: https://companieshouse.atlassian.net/jira/software/c/projects/DACT/boards/492?selectedIssue=DACT-1556

Adds an event for the "Go back to current directors" button