### PR TITLE
Reverting govuk-frontend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@companieshouse/api-sdk-node": "^2.0.334",
-        "@companieshouse/ch-node-utils": "^3.0.5",
+        "@companieshouse/ch-node-utils": "^2.1.13",
         "@companieshouse/node-session-handler": "^5.2.10",
         "@companieshouse/structured-logging-node": "^2.0.11",
         "@companieshouse/web-security-node": "^4.4.15",
@@ -30,7 +30,7 @@
         "cookie-parser": "^1.4.7",
         "express": "^5.2.1",
         "express-validator": "^6.15.0",
-        "govuk-frontend": "6.0.0",
+        "govuk-frontend": "5.14.0",
         "js-yaml": "^4.1.1",
         "luxon": "^2.5.2",
         "nunjucks": "^3.2.4",
@@ -614,9 +614,9 @@
       }
     },
     "node_modules/@companieshouse/ch-node-utils": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@companieshouse/ch-node-utils/-/ch-node-utils-3.0.5.tgz",
-      "integrity": "sha512-BE+5P1PNPZn8meLL4o152pAv+gIsd6rDhExBlWQ5SZStOShe8PCqLlEYp1ORWJxrALkMbneXL/T3esdu3X10ug==",
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/@companieshouse/ch-node-utils/-/ch-node-utils-2.1.13.tgz",
+      "integrity": "sha512-5p2Wvf/JNFBtdODxfWi/NxJPzdCR3sn3ah0qiJdaChIfgB6auDfTKC1wsYFaQY6l9s9RVzqNBevvXpae0vL07w==",
       "license": "MIT",
       "dependencies": {
         "@companieshouse/node-session-handler": "^5.2.4",
@@ -629,7 +629,7 @@
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "govuk-frontend": "^6.0.0"
+        "govuk-frontend": "^4.10.0 || ^5.10.0"
       }
     },
     "node_modules/@companieshouse/ch-node-utils/node_modules/@eslint/config-array": {
@@ -6777,9 +6777,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6794,9 +6791,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6811,9 +6805,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6828,9 +6819,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6845,9 +6833,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6862,9 +6847,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6879,9 +6861,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6896,9 +6875,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9134,9 +9110,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.0.0.tgz",
-      "integrity": "sha512-n1DUbQD6coHL3UkQS0yTbd4ziIxLBzkWBODVCjXMclSY7FvOGeHcTg3c72z6u7DQECQb0tfZofhPjGxPUOIizA==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.14.0.tgz",
+      "integrity": "sha512-MgfaXswIM6KpXS2T5gltEnzgVLgfM3UoE9+rYkhBiR0suaJ8Let31VZXQZqz9QhiPDbv28fW1nRjIyLujfZIBA==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
@@ -11537,13 +11513,12 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.2.1.tgz",
-      "integrity": "sha512-qD8KPh/2Zj/Kpx6nxhbCZ9TrXVhVBVkC/UNBVA2AWADc1JewcwIhNKUo+j0kiA6PqzTje8Ojc3D+hhmzy2+jkQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.3.0.tgz",
+      "integrity": "sha512-JpJpFaR7yKNb6WqKvJJ1MLbiuIQWQnbUUb06nDtf2/i8YWYYLEfP6xf9BwSJoJQg1wAy61EQB8dssQg64oX4aA==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/companieshouse/officer-filing-web#readme",
   "dependencies": {
     "@companieshouse/api-sdk-node": "^2.0.334",
-    "@companieshouse/ch-node-utils": "^3.0.5",
+    "@companieshouse/ch-node-utils": "^2.1.13",
     "@companieshouse/node-session-handler": "^5.2.10",
     "@companieshouse/structured-logging-node": "^2.0.11",
     "@companieshouse/web-security-node": "^4.4.15",
@@ -52,7 +52,7 @@
     "cookie-parser": "^1.4.7",
     "express": "^5.2.1",
     "express-validator": "^6.15.0",
-    "govuk-frontend": "6.0.0",
+    "govuk-frontend": "5.14.0",
     "js-yaml": "^4.1.1",
     "luxon": "^2.5.2",
     "nunjucks": "^3.2.4",


### PR DESCRIPTION
## Brief description of the change(s)

Set Gov Frontend back to 5.14.0 as 6.0.0 reverts the rebranding header.



## Jira ticket

https://companieshouse.atlassian.net/browse/ASM-1388

## Test notes

E2E regression test.



## Checklist
>
> Paste the ⭕️ emoji into the respective columns below. If a checklist item *is* applicable but you haven't done it, omit the emoji from both columns. You can optionally add notes to clear up ambiguity. Whitespace isn't important, as long as the emoji is within the cell `|  |` it will render correctly.

| Item                                                       | Done | Not applicable | Notes |
|:-----------------------------------------------------------|:----:|:--------------:|-------|
| Adhered to the CH style guide (required)                   |  ⭕️  |                |       |
| Added/updated logging                                      |      |        ⭕️        |       |
| Written tests                                              |      |        ⭕️        |       |
| Tested the new code in my local environment                |   ⭕️   |                |       |
| Updated Docker/ECS configs                                 |      |         ⭕️       |       |
| Updated release ticket description with any config changes |      |         ⭕️       |       |
| Updated release ticket to link to this work item           |      |       ⭕️         |       |
